### PR TITLE
Increses spacings between paragraphs and changes link color

### DIFF
--- a/source/assets/stylesheets/_index.scss
+++ b/source/assets/stylesheets/_index.scss
@@ -36,7 +36,8 @@
   &__example pre {
     border-bottom-right-radius: $base-border-radius;
     border-bottom-left-radius: $base-border-radius;
-    margin: 0;
+    margin-top: 0;
+    margin-bottom: $base-spacing;
   }
 
   &__example-caption {

--- a/source/assets/stylesheets/base/_typography.scss
+++ b/source/assets/stylesheets/base/_typography.scss
@@ -36,7 +36,7 @@ h4 {
 }
 
 p {
-  margin: 0 0 $small-spacing;
+  margin: 0 0 $base-spacing;
 
   a {
     font-weight: 400;

--- a/source/assets/stylesheets/base/_variables.scss
+++ b/source/assets/stylesheets/base/_variables.scss
@@ -38,7 +38,7 @@ $yellow: #FFCD57;
 $base-background-color: $lavender;
 $base-font-color: $white;
 $action-color: $yellow;
-$link-color: $dark-purple;
+$link-color: $yellow;
 
 // Border
 $base-border-color: $light-gray;


### PR DESCRIPTION
Why:

* It was hard to read, especially after code blocks and links were very
  hard to spot

This change addresses the need by:

* Increasing and standardizing the spacings between code blocks and
  paragraphs
* Increasing the contrast between the link color and the background

## Link color

For the links I ended up using the color already being used for the link in the banner, here's how it was in terms of contrast:

<img width="863" alt="old-links-diesel" src="https://cloud.githubusercontent.com/assets/166304/12842386/5ae02444-cbea-11e5-917f-6d4c5da5dd7f.png">

And how it is with the change:

<img width="804" alt="new-links-diesel" src="https://cloud.githubusercontent.com/assets/166304/12842392/66e92632-cbea-11e5-88d7-0fb12ed893db.png">

The red means it does not pass any level of the WCAG 2.0 on contrast ratio, the green means it passes the AA level for any size and the AAA level for sizes larger than 18pt.

## Spacings

For the spacings I made all of the most relevant bottom margin use `base-spacing` instead of `ems`. I tested in different screen sizes and it seems to be fine. Having more space let's the content breathe a bit more and improves readability. For the code blocks, I believe it was actually a mistake that they had no margin bottom. Here's how it was:

<img width="1182" alt="old-spacings-diesel" src="https://cloud.githubusercontent.com/assets/166304/12842438/c47018c4-cbea-11e5-950f-b2c12687667b.png">

And how it is with the changes:

<img width="1186" alt="new-spacings-diesel" src="https://cloud.githubusercontent.com/assets/166304/12842441/cf047186-cbea-11e5-8dcb-d4192adeb02f.png">

