### PR TITLE
Link to the up/down.sql in the demo repo

### DIFF
--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -129,6 +129,8 @@ main
         .demo__example
           .demo__example-browser
             .browser-bar up.sql
+            a.btn-demo-example href=demo_file_at_commit("migrations/20160202154039_create_posts/up.sql", first_commit)
+              | View on Github
             pre.demo__example-snippet
               code
                 | CREATE TABLE posts (
@@ -140,6 +142,8 @@ main
 
           .demo__example-browser
             .browser-bar down.sql
+            a.btn-demo-example href=demo_file_at_commit("migrations/20160202154039_create_posts/down.sql", first_commit)
+              | View on Github
             pre.demo__example-snippet
               code
                 | DROP TABLE posts


### PR DESCRIPTION
These were the only two files that didn't have a 'View on Github' link,
added it for consistency.