### PR TITLE
Update nightly version in getting started guide

### DIFF
--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -22,7 +22,7 @@ main
           PostgreSQL installed and running.
 
           Note: Diesel 0.5.0 currently compiles against nightly as of
-          `2016-02-09`. If you're following along with this guide, make sure
+          `2016-03-11`. If you're following along with this guide, make sure
           you're using a nightly older than that version, or add the steps in
           the final section to compile on stable
 


### PR DESCRIPTION
diesel_codegen doesn't compile on the version originally specified. As per https://github.com/sgrif/diesel/tree/master/diesel_codegen#using-on-nightly change to nightly 2016-03-11.