### PR TITLE
Added username and password for the DATABASE_URL.

### DIFF
--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -81,7 +81,7 @@ main
           .demo__example-browser
             pre.demo__example-snippet
               code
-                | echo DATABASE_URL=postgres://localhost/diesel_demo &gt; .env
+                | echo DATABASE_URL=postgres://username:password@localhost/diesel_demo &gt; .env
 
         markdown:
           Now Diesel CLI can set everything up for us.


### PR DESCRIPTION
I think that having the DATABASE_URL so that "username:password@" part of the url is also included is more noob-friendly – certainly more so that just getting an error like "fe_sendauth: no password supplied".

Of course, the error message itself could also suggest having the username and password in the format that is expected. I think that would align well with the Rust way of friendly error messages. What do you think? Should I send a pull request for that too?