### PR TITLE
Disable ligatures in code snippets

### DIFF
--- a/source/assets/stylesheets/base/_typography.scss
+++ b/source/assets/stylesheets/base/_typography.scss
@@ -80,4 +80,5 @@ pre {
 
 code {
   font-weight: bold;
+  @include font-feature-settings("liga" 0);
 }


### PR DESCRIPTION
Ligatures inside code snippets make the monospacing look weird.

This commit fixes that by turning off ligatures inside `<code>` tags.

Before (note the ligature of "ﬁ" in `filter`):
<img width="500" alt="screen shot of code snippet where the fi in filter is a ligature" src="https://cloud.githubusercontent.com/assets/1921012/19008866/456d303a-8723-11e6-8875-00b9c7209415.png">

After (no ligature):
<img width="462" alt="screen shot of code snippet where the fi in filter is not a ligature" src="https://cloud.githubusercontent.com/assets/1921012/19008872/49c66a48-8723-11e6-9c3a-6dbb86ac961d.png">