### PR TITLE
Add instructions for installing if you don't have mysql on your machine

### DIFF
--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -69,6 +69,30 @@ main
               code
                 | cargo install diesel_cli
 
+        aside.aside.aside--note
+          header.aside__header A Note on Installing diesel_cli
+          .aside__text
+            markdown:
+              If you run into the error:
+            .demo__example
+              .demo__example-browser
+                pre.demo__example-snippet
+                  code
+                    | note: ld: library not found for -lmysqlclient
+                      clang: error: linker command failed with exit code 1 (use -v to see invocation)
+            markdown:
+              You can resolve this issue by specifying the diesel
+              backends you want to install it with. If you only have
+              postgres installed, you can setup `diesel_cli` with only
+              postgres.
+            .demo__example
+              .demo__example-browser
+                pre.demo__example-snippet
+                  code
+                    | cargo install diesel_cli --no-default-features --features postgres
+
+
+
         markdown:
           We need to tell Diesel where to find our database. We do this by
           setting the `DATABASE_URL` environment variable. On our development


### PR DESCRIPTION
I think it is common enough to not have mysql on your machine it warrants an aside in the getting started doc.

Here is a look at what it looks like on my machine:

![screen shot 2017-05-01 at 8 57 26 pm](https://cloud.githubusercontent.com/assets/4482399/25603555/9886063a-2eb1-11e7-9b92-60498f560a8b.png)


## Questions

I don't totally love the syntax highlighting on the error message, but I couldn't figure out another style that looked better. Do you have a preference?