### PR TITLE
Document to build diesel_cli with just what you use

### DIFF
--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -42,8 +42,17 @@ main
           `sqlite`. You can list multiple.
 
           Please note that you may need to install the corresponding client libraries
-          for your operating system.
+          for your operating system. If they are not present, you might see errors like
+          this one:
 
+        .demo__example
+          .demo__example-browser
+            pre.demo__example-snippet
+              code
+                |  note: ld: library not found for -lpq
+                   clang: error: linker command failed with exit code 1
+
+        markdown:
           We're also going to use a tool called [`.env`][dotenv-rust] to manage our
           environment variables for us. We'll add it to our dependencies as well.
 
@@ -68,7 +77,8 @@ main
           just install it on our system.
 
           The CLI has the same features as the diesel library and you should pass
-          the same as you passed in `Cargo.toml`.
+          the same as you passed in `Cargo.toml`. `--no-default-features` deactivates
+          the default, which tries to build the tool with support for all databases.
 
           [diesel-cli]: https://github.com/sgrif/diesel/tree/master/diesel_cli
 

--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -37,9 +37,15 @@ main
                   cd diesel_demo
 
         markdown:
-          First, let's add Diesel to our dependencies. We're also going to use a
-          tool called [`.env`][dotenv-rust] to manage our environment variables
-          for us. We'll add it to our dependencies as well.
+          First, let's add Diesel to our dependencies. The features option lists the
+          databases we want to use. The current options are: `postgres`, `mysql` and
+          `sqlite`. You can list multiple.
+
+          Please note that you may need to install the corresponding client libraries
+          for your operating system.
+
+          We're also going to use a tool called [`.env`][dotenv-rust] to manage our
+          environment variables for us. We'll add it to our dependencies as well.
 
           [dotenv-rust]: https://github.com/slapresta/rust-dotenv
 
@@ -61,13 +67,16 @@ main
           project's code directly, we don't add it to `Cargo.toml`. Instead, we
           just install it on our system.
 
+          The CLI has the same features as the diesel library and you should pass
+          the same as you passed in `Cargo.toml`.
+
           [diesel-cli]: https://github.com/sgrif/diesel/tree/master/diesel_cli
 
         .demo__example
           .demo__example-browser
             pre.demo__example-snippet
               code
-                | cargo install diesel_cli
+                | cargo install diesel_cli --no-default-features --features postgres
 
         markdown:
           We need to tell Diesel where to find our database. We do this by


### PR DESCRIPTION
Document how to build diesel_cli without having sqlite-dev, mysql-dev and pg-dev installed.