### PR TITLE
Fix footer positioning on guide page

### DIFF
--- a/source/assets/stylesheets/_global.scss
+++ b/source/assets/stylesheets/_global.scss
@@ -1,6 +1,15 @@
+html {
+  height: 100%;
+}
+
 body {
   background: $lavender;
   color: $base-font-color;
+  position: relative;
+  min-height: 100%;
+  padding-bottom: $base-spacing * 5.2;
+  margin: 0;
+
 
   @include media($medium-screen-up) {
     font-size: $base-font-size;
@@ -17,6 +26,8 @@ body {
 
 body.index {
   background: linear-gradient($lavender, lighten($lavender, 40%));
+  background-repeat: no-repeat;
+  background-attachment: fixed;
 }
 
 .guide-wrapper {

--- a/source/assets/stylesheets/_index.scss
+++ b/source/assets/stylesheets/_index.scss
@@ -70,6 +70,7 @@
 .demo {
   @extend %section;
   padding-top: $base-spacing;
+  margin: 0 auto;
 
   &__example pre {
     border-bottom-right-radius: $base-border-radius;

--- a/source/assets/stylesheets/patterns/_footer.scss
+++ b/source/assets/stylesheets/patterns/_footer.scss
@@ -3,6 +3,10 @@ footer {
   border-bottom: solid 5px $action-color;
   padding: $base-spacing * 2;
   text-align: center;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
 
   p {
     margin: 0;


### PR DESCRIPTION
Prior to this commit on the guide page the footer would be halfway up
the page which looked weird. Now it's positioned at the bottom of the
page no matter what screen it's on. To do this we give it an absolute
positioning and make the body relative. A couple of tweaks were also
added so that the site still looks the same despite these changes in how
everything is positioned. Most notably still allowing the gradient
change in the background color to be the same on the homepage.