### PR TITLE
fix print schema

### DIFF
--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -279,11 +279,12 @@ main
           .demo__example-browser
             pre.demo__example-snippet
               code
-                | diesel migration run > src/schema.rs
+                | diesel print-schema > src/schema.rs
 
         markdown:
           That will generate the following file:
-
+          
+        .demo__example 
           .demo__example-browser
             .browser-bar src/schema.rs
             a.btn-demo-example href=getting_started_demo_file(1, "src/schema.rs")


### PR DESCRIPTION
replaces "migration run" with "print-schema", which is clearly what was meant.
also, the code block below was broken, this should fix it.