### PR TITLE
Replace backtick with code tags in textblock

### DIFF
--- a/source/partials/_demo.html.slim
+++ b/source/partials/_demo.html.slim
@@ -152,7 +152,7 @@ section.demo
                       ('Gordon', DEFAULT)
             p.demo__example-caption
               | If you need data from the rows you inserted, just change
-                `execute` to `get_result` or `get_results`. Diesel will take
+                <code>execute</code> to <code>get_result</code> or <code>get_results</code>. Diesel will take
                 care of the rest.
             .demo__example-browser
               .browser-bar Rust code


### PR DESCRIPTION
## Problem
The text in part of a demo block is interpreted as HTML and the backticks for code blocks show up as backticks instead.

## Solution
This replaces the backticks with \<code> tags. I tried using `markdown:`, but that cause a whole slew of other issues.