### PR TITLE
Adding a note about barrel into docs

### DIFF
--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -58,6 +58,14 @@ main
           project's code directly, we don't add it to `Cargo.toml`. Instead, we
           just install it on our system.
 
+          [diesel-cli]: https://github.com/sgrif/diesel/tree/master/diesel_cli
+
+        .demo__example
+          .demo__example-browser
+            pre.demo__example-snippet
+              code.bash
+                | cargo install diesel_cli
+
         aside.aside.aside--note
           header.aside__header Writing migrations in Rust
           .aside__text
@@ -66,14 +74,13 @@ main
               that enables you to write your migrations in Rust via the [barrel][barrel]
               crate. **Note** that diesel doesn't officially support this.
 
-          [diesel-cli]: https://github.com/sgrif/diesel/tree/master/diesel_cli
-          [barrel]: https://github.com/spacekookie/barrel
+              [barrel]: https://github.com/spacekookie/barrel
 
-        .demo__example
-          .demo__example-browser
-            pre.demo__example-snippet
-              code.bash
-                | cargo install diesel_cli
+            .demo__example
+              .demo__example-browser
+                pre.demo__example-snippet
+                  code.bash
+                    | cargo install diesel_cli --features="rust-migrations"
 
         aside.aside.aside--note
           header.aside__header A Note on Installing <code>diesel_cli</code>

--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -72,9 +72,12 @@ main
             markdown:
               There is an optional flag you can provide when installing `diesel_cli`
               that enables you to write your migrations in Rust via the [barrel][barrel]
-              crate. **Note** that diesel doesn't officially support this.
+              crate. Find a barrel specific guide [here][barrel-guide].
+              
+              **Note** that diesel doesn't officially support this.
 
-              [barrel]: https://github.com/spacekookie/barrel
+              [barrel]: https://spacekookie.github.io/barrel/
+              [barrel-guide]: https://github.com/spacekookie/barrel/blob/master/guides/diesel-setup.md
 
             .demo__example
               .demo__example-browser

--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -58,7 +58,16 @@ main
           project's code directly, we don't add it to `Cargo.toml`. Instead, we
           just install it on our system.
 
+        aside.aside.aside--note
+          header.aside__header Writing migrations in Rust
+          .aside__text
+            markdown:
+              There is an optional flag you can provide when installing `diesel_cli`
+              that enables you to write your migrations in Rust via the [barrel][barrel]
+              crate. **Note** that diesel doesn't officially support this.
+
           [diesel-cli]: https://github.com/sgrif/diesel/tree/master/diesel_cli
+          [barrel]: https://github.com/spacekookie/barrel
 
         .demo__example
           .demo__example-browser


### PR DESCRIPTION
Hey there,

I thought this would probably be the best place to mention that barrel exists. I'm not 100% sure on the phrasing, especially

> **Note** that diesel doesn't officially support this.

This sounds kinda ambiguous. Or what do you think?

Also, if you're rather barrel be mentioned somewhere else, let me know.
Cheers!