### PR TITLE
Be explicit about creating a lib

### DIFF
--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -35,7 +35,7 @@ main
           .demo__example-browser
             pre.demo__example-snippet
               code
-                | cargo new diesel_demo
+                | cargo new --lib diesel_demo
                   cd diesel_demo
 
         markdown:


### PR DESCRIPTION
The default for `cargo new` is now a binary crate, but later in this
tutorial it assumes you're building a library crate. Being explicit
about wanting a lib will work no matter what Rust version the reader is
using.