### PR TITLE
Don't pin versions in quickstart

### DIFF
--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -53,8 +53,8 @@ main
             pre.demo__example-snippet
               code.toml
                 | [dependencies]
-                  diesel = { version = "1.0.0", features = ["postgres"] }
-                  dotenv = "0.9.0"
+                  diesel = { version = "1", features = ["postgres"] }
+                  dotenv = "0.9"
 
         markdown:
           Diesel provides a separate [CLI][diesel-cli] tool to help manage your


### PR DESCRIPTION
If you use the code as is, you'll get pinned to `1.0.0` forever, which is likely not what most people want.

Alternatively, you could update this document regularly as new versions get released, but that also seems painful. This way, you only have to upgrade it once a new major version gets released.