### PR TITLE
Add "Embedded migrations" guide

### DIFF
--- a/source/views/guides/embedded-migrations.slim
+++ b/source/views/guides/embedded-migrations.slim
@@ -1,0 +1,38 @@
+---
+title: Embedding migrations
+---
+
+section.banner
+  .content-wrapper
+    .banner-wrapper
+      h2.banner__heading Embedding migrations
+
+main
+  section.demo
+    .content-wrapper
+      .guide-wrapper
+        markdown:
+          Sometimes you want your binary to manage the initialization and
+          migrations for the users, without asking them to use diesel_cli.
+          In this case you can embed your migrations into your binary with
+          `embed_migrations!`.
+
+        .demo__example
+          .demo__example-browser
+            .browser-bar src/lib.rs
+            a.btn-demo-example href="TODO"
+              | View on Github
+            pre.demo__example-snippet
+              code.rust
+                | embed_migrations!("../migrations/sqlite");
+
+                  fn main() {
+                      let connection = establish_connection();
+
+                      // This will run the necessary migrations.
+                      embedded_migrations::run(&connection);
+
+                      // By default the output is thrown out. If you want to redirect it to stdout, you
+                      // should call embedded_migrations::run_with_output.
+                      embedded_migrations::run_with_output(&connection, &mut std::io::stdout());
+                  }

--- a/source/views/guides/index.html.slim
+++ b/source/views/guides/index.html.slim
@@ -26,6 +26,9 @@ main
         a.guides-link(href="/guides/schema-in-depth")
           h4.guides-list-heading Schema in Depth
           p Ever wondered what exactly <code>diesel print-schema</code> and <code>table!</code> are doing? This guide will walk you through exactly what code gets generated, and how it's done.
+        a.guides-link(href="/guides/embedded-migrations")
+          h4.guides-list-heading Embedding migrations in a binary
+          p This guide explains how to embed migrations in your binary.
         a.guides-link(href="/guides/extending-diesel")
           h4.guides-list-heading Extending Diesel
           p Want to use a feature Diesel doesn't support?


### PR DESCRIPTION
I got a very good pointer in https://github.com/diesel-rs/diesel/issues/1840 and would like to add this to the guides list. I think I need to submit my snippet as an example to the diesel repo first, right?