### PR TITLE
Include note about running migrations in production in the getting started guide

### DIFF
--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -206,6 +206,19 @@ main
               If you want to use SQLite instead, you need to use `INTEGER`
               instead.
 
+        aside.aside.aside--note
+          header.aside__header A Note on Using Migrations in Production
+          .aside__text
+            markdown:
+              When preparing your app for use in production, you may want to run your migrations during
+              the application's initialization phase. You may also want to include the migration scripts
+              as a part of your code, to avoid having to copy them to your deployment location/image etc.
+
+              The [diesel_migrations](https://docs.rs/crate/diesel_migrations/) crate provides the `embed_migrations!` macro, allowing you to embed
+              migration scripts in the final binary. Once your code uses it, you can simply include `embedded_migrations::run(&db_conn)`
+              at the start of your `main` function to run migrations every time the application starts.
+
+
         markdown:
           OK enough SQL, let's write some Rust. We'll start by writing some code
           to show the last five published posts. The first thing we need to do is


### PR DESCRIPTION
I added a note providing a pointer for people interested in running migrations in production environments - something that took me a while to figure out lacking any such pointer in the docs.

Feedback on phrasing/location/format of the note is more than welcome.

Thanks in advance!