### PR TITLE
Change links to point to current repository url

### DIFF
--- a/source/partials/_banner.html.slim
+++ b/source/partials/_banner.html.slim
@@ -5,4 +5,4 @@ section.banner
       p.banner__sub-heading Diesel is the most productive way to interact with databases in Rust because of its safe and composable abstractions over queries.
       .btn-container
         a.btn.btn-primary.btn-download(href="/guides/getting-started") Get Started
-        a.btn.btn-secondary(href="https://github.com/sgrif/diesel") View on Github
+        a.btn.btn-secondary(href="https://github.com/diesel-rs/diesel") View on Github

--- a/source/partials/_banner_hi_gary.html.slim
+++ b/source/partials/_banner_hi_gary.html.slim
@@ -5,4 +5,4 @@ section.banner
       p.banner__sub-heading As we all know, operating systems peaked with OS/2 and BeOS. Why use anything else?
       .btn-container
         a.btn.btn-primary.btn-download(href="/guides/getting-started") Get Started
-        a.btn.btn-secondary(href="https://github.com/sgrif/diesel") View on Github
+        a.btn.btn-secondary(href="https://github.com/diesel-rs/diesel") View on Github

--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -62,7 +62,7 @@ main
           project's code directly, we don't add it to `Cargo.toml`. Instead, we
           just install it on our system.
 
-          [diesel-cli]: https://github.com/sgrif/diesel/tree/master/diesel_cli
+          [diesel-cli]: https://github.com/diesel-rs/diesel/tree/master/diesel_cli
 
         .demo__example
           .demo__example-browser


### PR DESCRIPTION
The site's been following redirects by GitHub for a while now after being transferred. I think it's better to just link directly to the repository, should that behavior change in the future.