### PR TITLE
Note that struct field order must match query

### DIFF
--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -310,6 +310,15 @@ main
 
           Any time we run or revert a migration, this file will get automatically updated.
 
+        aside.aside.aside--note
+          header.aside__header A Note on Field Order
+          .aside__text
+            markdown:
+                Using `#[derive(Queryable)]` assumes that the order of fields on the
+                `Post` struct matches the columns in the `posts` table, so make
+                sure to define them in the order seen in the `schema.rs` file.
+
+        markdown:
           Let's write the code to actually show us our posts.
 
           [the `table!` macro]: http://docs.diesel.rs/diesel/macro.table!.html


### PR DESCRIPTION
The "Getting Started" guide doesn't make explicit mention that struct field order matters, instead relying on a user seeing that in http://docs.diesel.rs/diesel/deserialize/trait.Queryable.html

This is a response to the thread at: https://github.com/diesel-rs/diesel/issues/1926