### PR TITLE
fix link to table macro

### DIFF
--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -309,6 +309,8 @@ main
           exactly to use that in the next example.
 
           Any time we run or revert a migration, this file will get automatically updated.
+          
+          [the `table!` macro]: http://docs.diesel.rs/diesel/macro.table.html
 
         aside.aside.aside--note
           header.aside__header A Note on Field Order
@@ -320,8 +322,6 @@ main
 
         markdown:
           Let's write the code to actually show us our posts.
-
-          [the `table!` macro]: http://docs.diesel.rs/diesel/macro.table!.html
 
         .demo__example
           .demo__example-browser


### PR DESCRIPTION
This link no longer worked, presumably because an "aside" block was inserted in-between.