### PR TITLE
Updated diesel and dotenv versions to latest stable in the docs.

### DIFF
--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -53,8 +53,8 @@ main
             pre.demo__example-snippet
               code.toml
                 | [dependencies]
-                  diesel = { version = "1.0.0", features = ["postgres"] }
-                  dotenv = "0.9.0"
+                  diesel = { version = "1.4.2", features = ["postgres"] }
+                  dotenv = "0.14.1"
 
         markdown:
           Diesel provides a separate [CLI][diesel-cli] tool to help manage your


### PR DESCRIPTION
People would love to start fresh projects with latest stable builds. To be consistent with crates.io, I have changed the versions to latest stable.