### PR TITLE
Clarify the diesel_cli feature installation process

### DIFF
--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -85,8 +85,8 @@ main
               This means you are missing the client library needed for a
               database backend -- `mysqlclient` in this case. You can resolve
               this issue by either installing the library (using the usual way
-              to do this depending on your operating system) or by specifying
-              the backends you want to install the CLI tool with.
+              to do this depending on your operating system) or by excluding the
+              undesired default library with the `--no-default-features` flag.
 
               For example, if you only have PostgreSQL installed, you can use
               this to install `diesel_cli` with only PostgreSQL:


### PR DESCRIPTION
For the naive reader, the previous phrasing can imply "--features mysql" actually installs the necessary mysqlclient library.   This new phrasing clarifies that the user can either A) install it on their own or B) exclude it from use by diesel_cli.

This came up in https://github.com/diesel-rs/diesel/issues/2214 where I mistakenly assumed the naive interpretation.