### PR TITLE
Added detail about diesel_cli dependencies

### DIFF
--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -74,7 +74,7 @@ main
           header.aside__header A Note on Installing <code>diesel_cli</code>
           .aside__text
             markdown:
-              If you run into an error like:
+              The diesel cli, by default, requires openssl, libpq, sqlite, and mysql. If you run into an error like:
             .demo__example
               .demo__example-browser
                 pre.demo__example-snippet


### PR DESCRIPTION
The added text comes directly from the diesel repo in the diesel_cli README.md.