### PR TITLE
Use Diesel 1.4.4 in "getting started" example and all GitHub links

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -40,7 +40,7 @@ helpers do
   end
 
   def repo_url(path)
-    "https://github.com/diesel-rs/diesel/tree/v1.3.0/#{path}"
+    "https://github.com/diesel-rs/diesel/tree/v1.4.4/#{path}"
   end
 
   def example_file(path)

--- a/source/partials/_banner.html.slim
+++ b/source/partials/_banner.html.slim
@@ -5,4 +5,4 @@ section.banner
       p.banner__sub-heading Diesel is the most productive way to interact with databases in Rust because of its safe and composable abstractions over queries.
       .btn-container
         a.btn.btn-primary.btn-download(href="/guides/getting-started") Get Started
-        a.btn.btn-secondary(href="https://github.com/diesel-rs/diesel") View on Github
+        a.btn.btn-secondary(href="https://github.com/diesel-rs/diesel") View on GitHub

--- a/source/partials/_banner_hi_gary.html.slim
+++ b/source/partials/_banner_hi_gary.html.slim
@@ -5,4 +5,4 @@ section.banner
       p.banner__sub-heading As we all know, operating systems peaked with OS/2 and BeOS. Why use anything else?
       .btn-container
         a.btn.btn-primary.btn-download(href="/guides/getting-started") Get Started
-        a.btn.btn-secondary(href="https://github.com/diesel-rs/diesel") View on Github
+        a.btn.btn-secondary(href="https://github.com/diesel-rs/diesel") View on GitHub

--- a/source/views/guides/all-about-inserts.html.slim
+++ b/source/views/guides/all-about-inserts.html.slim
@@ -33,7 +33,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L16-L26")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | table! {
@@ -64,7 +64,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L47-L49")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use schema::users::dsl::*;
@@ -90,7 +90,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L57")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql INSERT INTO "users" DEFAULT VALUES -- binds: []
 
@@ -106,7 +106,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L62-L64")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use schema::users::dsl::*;
@@ -120,7 +120,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L72-L73")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | INSERT INTO "users" ("name") VALUES ($1)
@@ -133,7 +133,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L80-83")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | insert_into(users)
@@ -147,7 +147,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L90-L91")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | INSERT INTO "users" ("name", "hair_color")
@@ -173,7 +173,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L30-L35")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use schema::users;
@@ -189,7 +189,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L98-L103")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use schema::users::dsl::*;
@@ -208,7 +208,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L113-L114")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | INSERT INTO "users" ("name", "hair_color")
@@ -222,7 +222,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L119-L126")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use schema::users::dsl::*;
@@ -241,7 +241,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L136-L137")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | INSERT INTO "users" ("name", "hair_color")
@@ -267,7 +267,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L142-L146")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use schema::users::dsl::*;
@@ -283,7 +283,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L155-L156")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | INSERT INTO "users" ("name") VALUES ($1), ($2)
@@ -312,7 +312,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L161-L165")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use schema::users::dsl::*;
@@ -330,7 +330,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L174-L175")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | INSERT INTO "users" ("name") VALUES ($1), (DEFAULT)
@@ -343,7 +343,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L180-L187")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use schema::users::dsl::*;
@@ -362,7 +362,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L199-L201")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | INSERT INTO "users" ("name", "hair_color")
@@ -376,7 +376,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L206-L213")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use schema::users::dsl::*;
@@ -395,7 +395,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L225-L227")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | INSERT INTO "users" ("name", "hair_color")
@@ -409,7 +409,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L232-L242")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use schema::users::dsl::*;
@@ -431,7 +431,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L255-L257")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | INSERT INTO "users" ("name", "hair_color")
@@ -456,7 +456,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L37-L44")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | #[derive(Queryable, PartialEq, Debug)]
@@ -475,7 +475,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L265-L295")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use diesel::select;
@@ -517,7 +517,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L306-L309")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | INSERT INTO "users" ("id", "name")
@@ -542,7 +542,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L317-L335")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use diesel::select;
@@ -570,7 +570,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L347-L350")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | INSERT INTO "users" ("id", "name") VALUES ($1, $2)
@@ -586,7 +586,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L355-L360")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use schema::users::dsl::*;
@@ -603,7 +603,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_inserts/src/lib.rs#L368-L370")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | INSERT INTO "users" ("name") VALUES ($1)

--- a/source/views/guides/all-about-updates.html.slim
+++ b/source/views/guides/all-about-updates.html.slim
@@ -24,7 +24,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_updates/src/lib.rs#L12-L21")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | table! {
@@ -45,7 +45,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_updates/src/lib.rs#L33-L38")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use posts::dsl::*;
@@ -61,7 +61,7 @@ main
           .demo__example-browser
             .browser-bar Generated SQL
             a.btn-demo-example href=example_file("postgres/all_about_updates/src/lib.rs#L40-L48")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql UPDATE "posts" SET "draft" = $1 -- binds: [false]
 
@@ -73,7 +73,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_updates/src/lib.rs#L50-L57")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use posts::dsl::*;
@@ -89,7 +89,7 @@ main
           .demo__example-browser
             .browser-bar Generated SQL
             a.btn-demo-example href=example_file("postgres/all_about_updates/src/lib.rs#L59-L71")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | UPDATE `posts` SET `draft` = ?
@@ -106,7 +106,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_updates/src/lib.rs#L23-L31")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | #[derive(Identifiable)]
@@ -127,7 +127,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_updates/src/lib.rs#L73-L76")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust diesel::update(&post).set(posts::draft.eq(false))
 
@@ -138,7 +138,7 @@ main
           .demo__example-browser
             .browser-bar Generated SQL
             a.btn-demo-example href=example_file("postgres/all_about_updates/src/lib.rs#L78-L93")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql UPDATE `posts` SET `draft` = ? WHERE `posts`.`id` = ?
 
@@ -149,7 +149,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_updates/src/lib.rs#L95-L100")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use posts::dsl::*;
@@ -163,7 +163,7 @@ main
           .demo__example-browser
             .browser-bar Generated SQL
             a.btn-demo-example href=example_file("postgres/all_about_updates/src/lib.rs#L102-L111")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | UPDATE `posts`
@@ -176,7 +176,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_updates/src/lib.rs#L113-L122")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use posts::dsl::*;
@@ -194,7 +194,7 @@ main
           .demo__example-browser
             .browser-bar Generated SQL
             a.btn-demo-example href=example_file("postgres/all_about_updates/src/lib.rs#L124-L137")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql UPDATE `posts` SET `title` = ?, `body` = ?
 
@@ -211,7 +211,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_updates/src/lib.rs#L139-L142")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust diesel::update(posts::table).set(&post)
 
@@ -222,7 +222,7 @@ main
           .demo__example-browser
             .browser-bar Generated SQL
             a.btn-demo-example href=example_file("postgres/all_about_updates/src/lib.rs#L144-L173")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | UPDATE `posts` SET
@@ -241,7 +241,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=example_file("postgres/all_about_updates/src/lib.rs#L175-L189")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | #[derive(AsChangeset)]
@@ -264,7 +264,7 @@ main
           .demo__example-browser
             .browser-bar Generated SQL
             a.btn-demo-example href=example_file("postgres/all_about_updates/src/lib.rs#L191-L211")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql UPDATE `posts` SET `body` = ?
 

--- a/source/views/guides/composing-applications.html.slim
+++ b/source/views/guides/composing-applications.html.slim
@@ -36,7 +36,7 @@ main
           .demo__example-browser
             .browser-bar src/krate/mod.rs
             a.btn-demo-example href="https://github.com/rust-lang/crates.io/blob/b4d49ac32c5561a7a4a0948ce5ba9ada7b8924fb/src/krate/mod.rs"
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use diesel::dsl::Eq;
@@ -60,7 +60,7 @@ main
           .demo__example-browser
             .browser-bar src/krate/mod.rs
             a.btn-demo-example href="https://github.com/rust-lang/crates.io/blob/b4d49ac32c5561a7a4a0948ce5ba9ada7b8924fb/src/krate/mod.rs"
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use diesel::dsl::Eq;
@@ -100,7 +100,7 @@ main
           .demo__example-browser
             .browser-bar src/krate/mod.rs
             a.btn-demo-example href="https://github.com/rust-lang/crates.io/blob/b4d49ac32c5561a7a4a0948ce5ba9ada7b8924fb/src/krate/mod.rs"
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use diesel::pg::Pg;
@@ -152,7 +152,7 @@ main
           .demo__example-browser
             .browser-bar src/krate/mod.rs
             a.btn-demo-example href="https://github.com/rust-lang/crates.io/blob/b4d49ac32c5561a7a4a0948ce5ba9ada7b8924fb/src/krate/mod.rs"
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use diesel::dsl::Select;
@@ -188,7 +188,7 @@ main
           .demo__example-browser
             .browser-bar src/krate/mod.rs
             a.btn-demo-example href="https://github.com/rust-lang/crates.io/blob/b4d49ac32c5561a7a4a0948ce5ba9ada7b8924fb/src/krate/mod.rs"
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use diesel::dsl::Filter;
@@ -211,7 +211,7 @@ main
           .demo__example-browser
             .browser-bar src/krate/mod.rs
             a.btn-demo-example href="https://github.com/rust-lang/crates.io/blob/b4d49ac32c5561a7a4a0948ce5ba9ada7b8924fb/src/krate/mod.rs"
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use diesel::expression::{Expression, AsExpression};
@@ -262,7 +262,7 @@ main
           .demo__example-browser
             .browser-bar src/krate/mod.rs
             a.btn-demo-example href="https://github.com/rust-lang/crates.io/blob/b4d49ac32c5561a7a4a0948ce5ba9ada7b8924fb/src/krate/mod.rs"
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | impl Crate {

--- a/source/views/guides/extending-diesel.html.slim
+++ b/source/views/guides/extending-diesel.html.slim
@@ -122,7 +122,7 @@ main
           .demo__example-browser
             .browser-bar src/pagination.rs
             a.btn-demo-example href=example_file("postgres/advanced-blog-cli/src/pagination.rs#L55-L69")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | impl&lt;T&gt; QueryFragment&lt;Pg&gt; for Paginated&lt;T&gt;
@@ -170,7 +170,7 @@ main
           .demo__example-browser
             .browser-bar src/pagination.rs
             a.btn-demo-example href=example_file("postgres/advanced-blog-cli/src/pagination.rs#L47-L53")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | impl_query_id!(Paginated&lt;T&gt;);
@@ -194,7 +194,7 @@ main
           .demo__example-browser
             .browser-bar src/pagination.rs
             a.btn-demo-example href=example_file("postgres/advanced-blog-cli/src/pagination.rs#L7-L32")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | pub trait Paginate: AsQuery + Sized {
@@ -247,7 +247,7 @@ main
           .demo__example-browser
             .browser-bar src/pagination.rs
             a.btn-demo-example href=example_file("postgres/advanced-blog-cli/src/pagination.rs#L34-L44")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | impl&lt;T&gt; Paginated&lt;T&gt; {
@@ -354,7 +354,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href="https://github.com/diesel-rs/diesel_full_text_search/blob/27b9946831caa8b08177c1818a50cb7f0563c9c0/src/lib.rs#L57-L62"
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | diesel_infix_operator!(Matches, " @@ ", backend: Pg);
@@ -383,7 +383,7 @@ main
           .demo__example-browser
             .browser-bar src/expression_methods/global_expression_methods.rs
             a.btn-demo-example href=repo_url("diesel/src/expression_methods/global_expression_methods.rs")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | pub trait ExpressionMethods: Expression + Sized {
@@ -416,7 +416,7 @@ main
           .demo__example-browser
             .browser-bar src/expression_methods/bool_expression_methods.rs
             a.btn-demo-example href=repo_url("diesel/src/expression_methods/bool_expression_methods.rs")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | pub trait BoolExpressionMethods
@@ -439,7 +439,7 @@ main
           .demo__example-browser
             .browser-bar src/expression/not.rs
             a.btn-demo-example href=repo_url("diesel/src/expression/not.rs#L27-L29")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | pub fn not&lt;T: AsExpression&lt;Bool&gt;&gt;(expr: T)
@@ -466,7 +466,7 @@ main
           .demo__example-browser
             .browser-bar src/expression/helper_types.rs
             a.btn-demo-example href=repo_url("diesel/src/expression/helper_types.rs#L18")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | pub type Eq&lt;Lhs, Rhs&gt; =

--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -49,7 +49,7 @@ main
           .demo__example-browser
             .browser-bar Cargo.toml
             a.btn-demo-example href=getting_started_demo_file(1, "Cargo.toml")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.toml
                 | [dependencies]
@@ -159,7 +159,7 @@ main
           .demo__example-browser
             .browser-bar up.sql
             a.btn-demo-example href=getting_started_demo_file(1, "migrations/20160815133237_create_posts/up.sql")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | CREATE TABLE posts (
@@ -172,7 +172,7 @@ main
           .demo__example-browser
             .browser-bar down.sql
             a.btn-demo-example href=getting_started_demo_file(1, "migrations/20160815133237_create_posts/down.sql")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.sql
                 | DROP TABLE posts
@@ -228,7 +228,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=getting_started_demo_file(1, "src/lib.rs")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | #[macro_use]
@@ -260,7 +260,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=getting_started_demo_file(1, "src/lib.rs")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | pub mod schema;
@@ -273,7 +273,7 @@ main
           .demo__example-browser
             .browser-bar src/models.rs
             a.btn-demo-example href=getting_started_demo_file(1, "src/models.rs")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | #[derive(Queryable)]
@@ -301,7 +301,7 @@ main
           .demo__example-browser
             .browser-bar src/schema.rs
             a.btn-demo-example href=getting_started_demo_file(1, "src/schema.rs")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | table! {
@@ -340,7 +340,7 @@ main
           .demo__example-browser
             .browser-bar src/bin/show_posts.rs
             a.btn-demo-example href=getting_started_demo_file(1, "src/bin/show_posts.rs")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | extern crate diesel_demo;
@@ -390,7 +390,7 @@ main
           .demo__example-browser
             .browser-bar src/models.rs
             a.btn-demo-example href=getting_started_demo_file(2, "src/models.rs")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use super::schema::posts;
@@ -408,7 +408,7 @@ main
           .demo__example-browser
             .browser-bar src/lib.rs
             a.btn-demo-example href=getting_started_demo_file(2, "src/lib.rs")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | use self::models::{Post, NewPost};
@@ -446,7 +446,7 @@ main
           .demo__example-browser
             .browser-bar src/bin/write_post.rs
             a.btn-demo-example href=getting_started_demo_file(2, "src/bin/write_post.rs")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | extern crate diesel_demo;
@@ -516,7 +516,7 @@ main
           .demo__example-browser
             .browser-bar src/bin/publish_post.rs
             a.btn-demo-example href=getting_started_demo_file(3, "src/bin/publish_post.rs")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | extern crate diesel_demo;
@@ -576,7 +576,7 @@ main
           .demo__example-browser
             .browser-bar src/bin/delete_post.rs
             a.btn-demo-example href=getting_started_demo_file(3, "src/bin/delete_post.rs")
-              | View on Github
+              | View on GitHub
             pre.demo__example-snippet
               code.rust
                 | extern crate diesel_demo;

--- a/source/views/guides/getting-started.html.slim
+++ b/source/views/guides/getting-started.html.slim
@@ -53,7 +53,7 @@ main
             pre.demo__example-snippet
               code.toml
                 | [dependencies]
-                  diesel = { version = "1.4.2", features = ["postgres"] }
+                  diesel = { version = "1.4.4", features = ["postgres"] }
                   dotenv = "0.15.0"
 
         markdown:


### PR DESCRIPTION
Hey! Thanks for building Diesel! 👏

- I copied and pasted the Getting Started examples, and the Rust plugin from my editor told me that the versions were out of date. Turns out that the GitHub links also pointed to tag 1.3.0 not the latest, 1.4.4.
- Keeping these up to date is a little bit of a maintenance burden, but I couldn't find such a thing as a "latest" tag.
- Also correctly capitalize GitHub. It's trivial, but I noticed one and then I noticed them all. 😄

----

Unfortunately I've been unable to test the changes locally - installing Ruby 2.3.3 informed me that it's EoL, I couldn't build the JSON gem under that version, and so Middleman was unhappy. I continued by upgrading to Ruby 2.6.6 and `bundle update`ing everything, but I figured that was a little bloaty for this PR as Middleman warned about a bunch of deprecations in v4.3. If you'd like me to do that in a separate PR to save you the extra work, I can do.