### PR TITLE
Fix links to disel operators

### DIFF
--- a/source/views/guides/extending-diesel.html.slim
+++ b/source/views/guides/extending-diesel.html.slim
@@ -294,9 +294,9 @@ main
           [`diesel_infix_operator!`], [`diesel_postfix_operator!`] and
           [`diesel_prefix_operator!`].
 
-          [`diesel_infix_operator!`]: (//docs.diesel.rs/diesel/macro.diesel_infix_operator.html)
-          [`diesel_postfix_operator!`]: (//docs.diesel.rs/diesel/macro.diesel_postfix_operator.html)
-          [`diesel_prefix_operator!`]: (//docs.diesel.rs/diesel/macro.diesel_prefix_operator.html)
+          [`diesel_infix_operator!`]: //docs.diesel.rs/diesel/macro.diesel_infix_operator.html
+          [`diesel_postfix_operator!`]: //docs.diesel.rs/diesel/macro.diesel_postfix_operator.html
+          [`diesel_prefix_operator!`]: //docs.diesel.rs/diesel/macro.diesel_prefix_operator.html
 
           All of these macros have the same signature.
           They take between two and four arguments.


### PR DESCRIPTION
Currently the resulting links look the following way:
http://diesel.rs/guides/extending-diesel/(//docs.diesel.rs/diesel/macro.diesel_infix_operator.html)
which is wrong.