### PR TITLE
Redirecting to the right page

### DIFF
--- a/src/guides/schema-in-depth.md
+++ b/src/guides/schema-in-depth.md
@@ -23,7 +23,7 @@ This command will establish a database connection, query for a list of all the t
 and their columns, and generate `table!` invocations for each one.
 `diesel print-schema` will skip any table names which start with `__` (a double underscore).
 Diesel can be configured to automatically re-run `diesel print-schema`
-whenever you run migrations. See [Configuring Diesel CLI] for details.
+whenever you run migrations. See [Configuring Diesel CLI](./configuring-diesel-cli.html) for details.
 
 `table!` is where the bulk of the code gets generated. If you wanted to,
 you could see the actual exact code that gets generated


### PR DESCRIPTION
Configuring Diesel CLI redirects to .md file which gives 404, so changing it to HTML