### PR TITLE
Increase footer margin for small screens

### DIFF
--- a/assets/stylesheets/application.css
+++ b/assets/stylesheets/application.css
@@ -611,10 +611,11 @@ body {
   color: #fff;
   position: relative;
   min-height: 100%;
-  padding-bottom: 7.8em;
+  padding-bottom: 15em;
   margin: 0; }
   @media screen and (min-width: 40em) {
     body {
+      padding-bottom: 7.8em;
       font-size: 1.125em; }
       body h2 {
         font-size: 2.25em; }


### PR DESCRIPTION
This simple change fixes an issue on small screens (mobile phones) where the footer overlaps the last few lines of content:

![Screenshot](https://user-images.githubusercontent.com/1489823/129081576-3c66e4b0-aa23-4d71-9ccd-d65fd573360b.png)
