### PR TITLE
Change Examples link to point to 1.4.x branch instead of master

### DIFF
--- a/src/guides/getting-started.md
+++ b/src/guides/getting-started.md
@@ -15,7 +15,7 @@ which stands for "Create Read Update Delete". Each step in this guide will build
 and is meant to be followed along.
 
 **This guide assumes that you're using PostgreSQL.** Before we start,
-make sure you have PostgreSQL installed and running. If you are using some different database, like for example SQLite, some examples won't just run as the implemented API might differ. In the project repository, you may find various [examples](https://github.com/diesel-rs/diesel/tree/master/examples/) for every supported database. 
+make sure you have PostgreSQL installed and running. If you are using some different database, like for example SQLite, some examples won't just run as the implemented API might differ. In the project repository, you may find various [examples](https://github.com/diesel-rs/diesel/tree/1.4.x/examples) for every supported database. 
 
 <aside class = "aside aside--note">
 <header class = "aside__header">A note on Rust versions:</header>


### PR DESCRIPTION
Like the title says, change the `examples` link to point to the correct version branch the example is written for

in response to https://github.com/diesel-rs/diesel/issues/3065#issuecomment-1057290586