### PR TITLE
Fix logo clipping during animation

### DIFF
--- a/assets/stylesheets/application.css
+++ b/assets/stylesheets/application.css
@@ -843,7 +843,8 @@ body.index {
     .main-header h1 .logo {
       height: 75px;
       width: auto;
-      display: block; }
+      display: block;
+      overflow: visible; }
       @media screen and (min-width: 40em) {
         .main-header h1 a,
         .main-header h1 .logo {


### PR DESCRIPTION
Hey there,

Stumbled across the Diesel docs site and noticed that the jerrycan ends up clipping when the logo animates:

<img width="300" alt="image" src="https://user-images.githubusercontent.com/1179754/180586183-d4f8b0a5-8ccc-4647-9ab3-eaf0fe033ee7.png">

Added `overflow: visible` to the `.logo` class and it fixes this issue. Tested in Firefox, Safari, and Chromium.