### PR TITLE
Make copy of built pages work on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ guides: guides/all-about-updates.html guides/all-about-inserts.html guides/compo
 docs: docs/index.html
 
 page: index.html guides docs
-	cp assets/ out -r
+	cp -R assets out
 
 clean:
 	rm out -r


### PR DESCRIPTION
Discussed in #166, the existing command `cp assets/ out -r` doesn't work correctly on MacOS.

I changed it to `cp -R assets out` and the build artifacts are correctly copied to the `out` directory.

I found a random Linux REPL online and made some dummy directories+files and used the same command and it seemed to work as expected. @JohnTitor also mentioned in #166 that they tested this on Linux and it worked.