### PR TITLE
Fix section name: print-schema -> print_schema

### DIFF
--- a/src/guides/configuring-diesel-cli.md
+++ b/src/guides/configuring-diesel-cli.md
@@ -97,7 +97,7 @@ SQLite and MySQL are using a fixed set of sql types.
 [diesel.toml]()
 
 ```toml
-[print-schema]
+[print_schema]
 # skip generating missing sql type definitions
 generate_missing_sql_type_definitions = false
 ```


### PR DESCRIPTION
Hi, it looks like this might be a typo. Otherwise the section name would be inconsistent with other examples.