### PR TITLE
Improve :focus link styling

### DIFF
--- a/assets/stylesheets/application.css
+++ b/assets/stylesheets/application.css
@@ -575,6 +575,8 @@ a {
     color: #1f1f2d; }
   a:active, a:focus {
     outline: none; }
+  a:focus {
+    text-decoration: underline; }
 
 hr {
   border-bottom: 1px solid #D5D5D5;
@@ -844,7 +846,12 @@ body.index {
       height: 75px;
       width: auto;
       display: block;
-      overflow: visible; }
+      overflow: visible; 
+      box-sizing: content-box;
+      padding-bottom: 5px;
+    }
+    .main-header h1 a:focus .logo {
+        border-bottom: 2px solid #FFCD57;}
       @media screen and (min-width: 40em) {
         .main-header h1 a,
         .main-header h1 .logo {
@@ -865,7 +872,9 @@ body.index {
         margin-right: 0.75em; }
     .main-header .header-nav a {
       color: #fff; }
-      .main-header .header-nav a:hover {
+      .main-header .header-nav a:hover, 
+      .main-header .header-nav a:focus, 
+      .main-header .header-nav a:active {
         color: #FFCD57; }
 
 .vertical-tabs-container {
@@ -1034,6 +1043,13 @@ footer {
   left: 0; }
   footer p {
     margin: 0; }
+  footer a:active,
+  footer a:hover,
+  footer a:focus {
+    color: #FFCD57;
+    text-decoration: underline;}
+
+
 
 div.demo__example-browser {
   background: #2B303B;


### PR DESCRIPTION
Tab navigation through the site is currently not so great, this PR aims to improve the visual indicators on links throughout the site to make it more clear you are focus'd on the intractable elements on the page. 

* Add focus underline to all links & main logo.
    * Previously there was no indication you were focus'd on the link containing the logo [example](https://i.imgur.com/cVcAvV3.png)
    * Add focus underline styles to logo to match the updated link focus styling [example](https://i.imgur.com/Obr1qLI.png)
    * This also adds underline to ALL links with focus. examples: [1](https://imgur.com/B8b7Ixn.png) [2](https://imgur.com/kbPosQV.png) [3](https://imgur.com/Al4OPAg.png) [4](https://i.imgur.com/hoXCfYd.png)
* Add focus colors to main-header links.
    * Previously there was no indication that you were focusing a link in the main-header. [example](https://i.imgur.com/p2gG5uV.png)
    * Apply existing hover colors for focus/active states [example](https://i.imgur.com/csopKyE.png)
* Changed color of footer link to prevent it from being "hidden" due to color contrast
    * Previously hover/active/focus styling colors have very poor contrast with footer background. [example](https://i.imgur.com/D2mfTFj.png)
    * Instead keep the link color the same, and rely on the underline decoration to indicate hover/focus/active state [example](https://i.imgur.com/I3Hxgc0.png)
    * Worth exploring other colors to highlight with, but I using just underline seems like a large improvement over current state
 