### PR TITLE
Extend getting-started guide with new example for getting a post

### DIFF
--- a/src/guides/getting-started.md
+++ b/src/guides/getting-started.md
@@ -587,7 +587,7 @@ use diesel_demo_step_3_sqlite::*;
 use std::env::args;
 
 fn main() {
-    use self::schema::posts::dsl::{posts, id};
+    use self::schema::posts::dsl::{id, posts};
 
     let post_id = args()
         .nth(1)

--- a/src/guides/getting-started.md
+++ b/src/guides/getting-started.md
@@ -574,11 +574,11 @@ Published post Diesel demo
 ```
 
 Additionally let's implement a possibility of fetching a single post. We will display the post id with its title.
-Notice [`.optional()`] call. This returns `Option<Post>` instead of throwing an error, which we can then use in our matching pattern. For additional methods of `QueryDsl` refer to the [`documentation`]
+Notice [`.optional()`] call. This returns `Option<Post>` instead of throwing an error, which we can then use in our matching pattern. For additional methods to modify the constructed select statements refer to the [`documentation` of `QueryDsl`]
 
 
 [`.optional()`]: https://docs.diesel.rs/2.1.x/diesel/result/trait.OptionalExtension.html#tymethod.optional
-[`documentation`]: https://docs.diesel.rs/2.1.x/diesel/query_dsl/trait.QueryDsl.html
+[`documentation` of `QueryDsl`]: https://docs.diesel.rs/2.1.x/diesel/query_dsl/trait.QueryDsl.html
 
 ::: code-block
 

--- a/src/guides/getting-started.md
+++ b/src/guides/getting-started.md
@@ -573,6 +573,58 @@ That's it! Let's try it out with `cargo run --bin publish_post 1`.
 Published post Diesel demo
 ```
 
+Additionally let's implement a possibility of fetching a single post. We will display the post id with its title.
+Notice `optional()` call. This returns `Option<Post>` instead of throwing an error, which we can then use in our matching pattern.
+
+::: code-block
+
+[src/bin/get_post.rs](https://github.com/diesel-rs/diesel/blob/2.1.x/examples/postgres/getting_started_step_3/src/bin/get_post.rs)
+
+```rust
+use self::models::Post;
+use diesel::prelude::*;
+use diesel_demo_step_3_sqlite::*;
+use std::env::args;
+
+fn main() {
+    use self::schema::posts::dsl::{posts, id};
+
+    let post_id = args()
+        .nth(1)
+        .expect("get_post requires a post id")
+        .parse::<i32>()
+        .expect("Invalid ID");
+    
+    let connection = &mut establish_connection();
+
+    let post = connection
+        .transaction(|connection| {
+            let post = posts.find(id).select(Post::as_select())
+                .first(connection)
+                .optional()?; // This allows for returning an Option<Post>, otherwise it will throw an error
+
+            match post {
+                Some(post) => Ok(post),
+                None => Err(diesel::result::Error::NotFound),
+            }
+        })
+        .unwrap_or_else(|_: diesel::result::Error| panic!("Unable to find post {}", post_id));
+
+    println!("Post with id: {} has a title: {}", post.id, post.title);
+}
+```
+
+:::
+
+We can see our post with `cargo run --bin get_post 1`.
+
+
+```
+ Compiling diesel_demo v0.1.0 (file:///Users/sean/Documents/Projects/open-source/diesel_demo)
+   Running `target/debug/get_post 1`
+   Post with id: 1 has a title: Diesel demo
+```
+
 And now, finally, we can see our post with `cargo run --bin show_posts`.
 
 ```


### PR DESCRIPTION
This PR adds new example for getting a single post item from the database in `Getting Started` guide.

This closes the issue #201.

Here are the screenshots of the UI:

First part:
<img width="1242" alt="Zrzut ekranu 2023-07-13 o 17 35 56" src="https://github.com/sgrif/diesel.rs-website/assets/37155981/b4a5213b-0823-43c7-b75d-0ba18f428c18">



Second part:
<img width="1249" alt="Zrzut ekranu 2023-07-13 o 17 36 07" src="https://github.com/sgrif/diesel.rs-website/assets/37155981/ed7fada6-c9b3-4430-a168-5e77e1e72d58">


