### PR TITLE
Add missing import

### DIFF
--- a/src/guides/getting-started.md
+++ b/src/guides/getting-started.md
@@ -587,6 +587,7 @@ Notice [`.optional()`] call. This returns `Option<Post>` instead of throwing an 
 ```rust
 use self::models::Post;
 use diesel::prelude::*;
+use diesel_demo::*;
 use std::env::args;
 
 fn main() {


### PR DESCRIPTION
This PR adds missing import for `get_post` method to make example runnable