### PR TITLE
Fix misleading column type in guides/relations.md

### DIFF
--- a/src/guides/relations.md
+++ b/src/guides/relations.md
@@ -105,7 +105,7 @@ CREATE TABLE pages (
   id SERIAL PRIMARY KEY,
   page_number INT NOT NULL,
   content TEXT NOT NULL,
-  book_id SERIAL REFERENCES books(id)
+  book_id INTEGER NOT NULL REFERENCES books(id)
 );
 ```
 


### PR DESCRIPTION
Recently reading the guide "relations" I have noticed the misleading data type "SERIAL" for "book_id" column at the table "pages" definition, where the type "INTEGER NOT NULL" is originally implied.