### PR TITLE
Update relations.md

### DIFF
--- a/src/guides/relations.md
+++ b/src/guides/relations.md
@@ -494,7 +494,7 @@ And the corresponding down migration.
 
 ::: code-block
 
-[up.sql](https://github.com/diesel-rs/diesel/blob/2.1.x/examples/postgres/relations/migrations/2023-02-17-084617_add_books_authors/down.sql)
+[down.sql](https://github.com/diesel-rs/diesel/blob/2.1.x/examples/postgres/relations/migrations/2023-02-17-084617_add_books_authors/down.sql)
 
 ```sql
 DROP TABLE books_authors;


### PR DESCRIPTION
Solve Issue #200

> **Typo in migration file name**
In [Relations](https://diesel.rs/guides/relations.html) topic, "many-to-many or m:n" section, the "down" migration file for books_authors table (DROP TABLE books_authors;) should be renamed as down.sql instead of up.sql.