### PR TITLE
Rename "Getting Started" to "Getting Started with Diesel"

### DIFF
--- a/src/guides/getting-started.md
+++ b/src/guides/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: "Getting Started"
+title: "Getting Started with Diesel"
 lang: en-US
 css: ../assets/stylesheets/application.css
 include-after: |


### PR DESCRIPTION
Currently the lack of a favicon and a generic page title makes the guide quite difficult to find if you have lots of tabs open:

<img width="375" alt="Screenshot 2023-11-13 at 12 33 52" src="https://github.com/sgrif/diesel.rs-website/assets/1027207/7a79e9ee-0452-4d5f-99c2-abcd5e4e90c6">


This PR adds "Diesel" into the getting started guide title.