### PR TITLE
Fix typo in "Schema in Depth"

### DIFF
--- a/src/guides/schema-in-depth.md
+++ b/src/guides/schema-in-depth.md
@@ -17,8 +17,8 @@ and [`table!`] do. For `table!`, we will show a simplified version of the actual
 that gets generated, and explain how each piece is relevant to you.
 If you've ever been confused about what exactly is getting generated,
 or what `use schema::posts::dsl::*` means, this is the right place to be.
-Another way to get an overview of which types are available where is to open 
-the API documentation of your current crate via `cargo docs --open` and navigate
+Another way to get an overview of which types are available where is to open
+the API documentation of your current crate via `cargo doc --open` and navigate
 to the relevant module there.
 
 `diesel print-schema` is a command provided by Diesel CLI.


### PR DESCRIPTION
The correct command is `cargo doc --open` not `cargo docs --open`.