### PR TITLE
added cargo-binstall command for diesel_cli

### DIFF
--- a/src/guides/getting-started.md
+++ b/src/guides/getting-started.md
@@ -83,6 +83,19 @@ powershell -c "irm https://github.com/diesel-rs/diesel/releases/download/v2.2.0/
 
 :::
 
+You also can use [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) for this. To install diesel cli with `cargo binstall` run the following command:
+
+::: code-block
+
+[Install with cargo binstall]()
+
+```sh
+cargo binstall diesel_cli
+```
+:::
+
+This automatically finds the right binary for your system.
+
 Alternatively you can manually install diesel cli by using `cargo install:`
 
 ::: code-block
@@ -92,15 +105,6 @@ Alternatively you can manually install diesel cli by using `cargo install:`
 ```sh
 cargo install diesel_cli
 ```
-
-### Prebuilt binaries with cargo-binstall :
-
-The cli can also be installed using [cargo-binstall](https://github.com/cargo-bins/cargo-binstall), which will lookup for prebuilt binaries for your system . To install with cargo-binstall, run:
-
-```sh
-cargo binstall diesel_cli
-```
-
 :::
 
 <aside class = "aside aside--note">

--- a/src/guides/getting-started.md
+++ b/src/guides/getting-started.md
@@ -93,6 +93,14 @@ Alternatively you can manually install diesel cli by using `cargo install:`
 cargo install diesel_cli
 ```
 
+### Prebuilt binaries with cargo-binstall :
+
+The cli can also be installed using [cargo-binstall](https://github.com/cargo-bins/cargo-binstall), which will lookup for prebuilt binaries for your system . To install with cargo-binstall, run:
+
+```sh
+cargo binstall diesel_cli
+```
+
 :::
 
 <aside class = "aside aside--note">


### PR DESCRIPTION
Added [cargo-binstall ](https://github.com/cargo-bins/cargo-binstall) command to make installation (diesel_cli) way more convenient and easier  since some member of the community seems to  struggle with cargo install