### PR TITLE
Add example code from other databases to Getting Started document

### DIFF
--- a/assets/stylesheets/application.css
+++ b/assets/stylesheets/application.css
@@ -1106,6 +1106,16 @@ div.vertical-tabs-container {
   .community-project p {
     margin-bottom: 0; }
 
+    
+.mysql-example, .sqlite-example {
+  display:none;
+}
+/* Use PostgreSQL as default DB type for the getting started page 
+ (it will also be selected if javascript is broken/disabled)*/
+.postgres-example {
+  display:block;
+}
+
 /* Fix overflow issue in mobile screen */
 
 @media screen and (min-width: 420px) {

--- a/src/guides/getting-started.md
+++ b/src/guides/getting-started.md
@@ -4,11 +4,58 @@ lang: en-US
 css: ../assets/stylesheets/application.css
 include-after: |
     <script src="../assets/javascripts/application.js"></script>
+    <script type="text/javascript">
+    // this code is ripped off from the home page's tab selector code
+    function change_db_type(evt, db_type) {
+        // Declare all variables
+        var i, examples_content, db_type_buttons;
+
+        // Get all elements with class="postgres-example" and hide them
+        examples_content = document.getElementsByClassName("postgres-example");
+        for (i = 0; i < examples_content.length; i++) {
+            examples_content[i].style.display = "none";
+        };
+
+        // Get all elements with class="sqlite-example" and hide them
+        examples_content = document.getElementsByClassName("sqlite-example");
+        for (i = 0; i < examples_content.length; i++) {
+            examples_content[i].style.display = "none";
+        }
+
+        // Get all elements with class="mysql-example" and hide them
+        examples_content = document.getElementsByClassName("mysql-example");
+        for (i = 0; i < examples_content.length; i++) {
+            examples_content[i].style.display = "none";
+        }
+
+        // Get all elements with class="tablinks" and remove the class "btn-primary"
+        db_type_buttons = document.getElementsByClassName("db-type-button");
+        for (i = 0; i < db_type_buttons.length; i++) {
+            db_type_buttons[i].className = db_type_buttons[i].className.replace(" btn-primary", "");
+        }
+
+        // Get all elements with the now-selected class name and show them
+        examples_content = document.getElementsByClassName(db_type + "-example");
+        console.log(examples_content);
+        for (i = 0; i < examples_content.length; i++) {
+            examples_content[i].style.display = "block";
+        }
+        // set the link that was clicked to be active
+        evt.currentTarget.className += " btn-primary";
+    }
+    </script>
+
 ---
 
 ::: demo
 ::: content-wrapper
 ::: guide-wrapper
+
+::: btn-container
+<!-- Select PostgreSQL button by default. If this ever changes, also modify the postgres-example CSS class -->
+[PostgreSQL](javascript:void(0)){.btn .btn-primary .db-type-button onclick="change_db_type(event, 'postgres')"} [SQLite](javascript:void(0)){.btn .db-type-button onclick="change_db_type(event, 'sqlite')"} [MySQL](javascript:void(0)){.btn .db-type-button onclick="change_db_type(event, 'mysql')"} 
+:::
+
 
 For this guide, we're going to walk through some simple examples for each of the pieces of CRUD,
 which stands for "Create Read Update Delete". Each step in this guide will build on the previous
@@ -47,6 +94,7 @@ as well.
 
 [dotenvy]: https://github.com/allan2/dotenvy
 
+::: postgres-example
 ::: code-block
 
 [Cargo.toml](https://github.com/diesel-rs/diesel/blob/2.2.x/examples/postgres/getting_started_step_1/Cargo.toml)
@@ -57,6 +105,37 @@ diesel = { version = "2.2.0", features = ["postgres"] }
 dotenvy = "0.15"
 ```
 
+:::
+:::
+
+
+::: {.sqlite-example}
+::: code-block 
+
+[Cargo.toml (SQLite)](https://github.com/diesel-rs/diesel/blob/2.2.x/examples/sqlite/getting_started_step_1/Cargo.toml)
+
+```toml
+[dependencies]
+diesel = { version = "2.2.0", features = ["sqlite"] }
+dotenvy = "0.15"
+libsqlite3-sys = { workspace = true, features = ["bundled"] }
+```
+
+:::
+:::
+
+::: {.mysql-example}
+::: code-block 
+
+[Cargo.toml (MySQL)](https://github.com/diesel-rs/diesel/blob/2.2.x/examples/mysql/getting_started_step_1/Cargo.toml)
+
+```toml
+[dependencies]
+diesel = { version = "2.2.0", features = ["mysql"] }
+dotenvy = "0.15"
+```
+
+:::
 :::
 
 ## Installing Diesel CLI

--- a/src/guides/getting-started.md
+++ b/src/guides/getting-started.md
@@ -52,7 +52,7 @@ include-after: |
 ::: guide-wrapper
 
 ::: btn-container
-<!-- Select PostgreSQL button by default. If this ever changes, also modify the postgres-example CSS class -->
+<!-- PostgreSQL button is selected by default. If this ever changes, also modify the postgres-example CSS class -->
 [PostgreSQL](javascript:void(0)){.btn .btn-primary .db-type-button onclick="change_db_type(event, 'postgres')"} [SQLite](javascript:void(0)){.btn .db-type-button onclick="change_db_type(event, 'sqlite')"} [MySQL](javascript:void(0)){.btn .db-type-button onclick="change_db_type(event, 'mysql')"} 
 :::
 
@@ -61,7 +61,7 @@ For this guide, we're going to walk through some simple examples for each of the
 which stands for "Create Read Update Delete". Each step in this guide will build on the previous
 and is meant to be followed along.
 
-Before we start, make sure you have PostgreSQL installed and running. If you are using some different database, like for example SQLite, some examples won't just run as the implemented API might differ. In the project repository, you may find various [examples](https://github.com/diesel-rs/diesel/tree/2.2.x/examples) for every supported database. 
+Before we start, make sure you have one of PostgreSQL, SQLite, or MySQL installed and running. In the project repository, you may find various [examples](https://github.com/diesel-rs/diesel/tree/2.2.x/examples) for every supported database. 
 
 <aside class = "aside aside--note">
 <header class = "aside__header">A note on Rust versions:</header>
@@ -97,7 +97,7 @@ as well.
 ::: postgres-example
 ::: code-block
 
-[Cargo.toml](https://github.com/diesel-rs/diesel/blob/2.2.x/examples/postgres/getting_started_step_1/Cargo.toml)
+[Cargo.toml (PostgreSQL)](https://github.com/diesel-rs/diesel/blob/2.2.x/examples/postgres/getting_started_step_1/Cargo.toml)
 
 ```toml
 [dependencies]
@@ -118,7 +118,6 @@ dotenvy = "0.15"
 [dependencies]
 diesel = { version = "2.2.0", features = ["sqlite"] }
 dotenvy = "0.15"
-libsqlite3-sys = { workspace = true, features = ["bundled"] }
 ```
 
 :::
@@ -211,12 +210,30 @@ By default diesel CLI depends on the following client libraries:
 
 If you are not sure on how to install those dependencies please consult the documentation of the corresponding dependency or your distribution package manager. By default diesel will dynamically link these libraries, which means they need to be present on your system at build and runtime.
 
+::: postgres-example
 For example, if you only have PostgreSQL installed, you can use this to install `diesel_cli`
 with only PostgreSQL:
 
 ```sh
 cargo install diesel_cli --no-default-features --features postgres
 ```
+:::
+::: sqlite-example
+For example, if you only have SQLite installed, you can use this to install `diesel_cli`
+with only SQLite:
+
+```sh
+cargo install diesel_cli --no-default-features --features sqlite
+```
+:::
+::: mysql-example
+For example, if you only have MySQL installed, you can use this to install `diesel_cli`
+with only MySQL:
+
+```sh
+cargo install diesel_cli --no-default-features --features mysql
+```
+:::
 
 If you are unsure how to configure these dependencies checkout [diesel CI](https://github.com/diesel-rs/diesel/blob/master/.github/workflows/ci.yml#L63-L222) configuration for a working setup for different operating systems.
 
@@ -643,7 +660,7 @@ pub struct Post {
 [`#[derive(Queryable)]`] will generate all of the code needed to load a `Post` struct from a SQL query. 
 [`#[derive(Selectable)]`] will generate code to construct a matching select clause based on your model type based on the 
 table defined via `#[diesel(table_name = crate::schema::posts)]`. 
-`#[diesel(check_for_backend(diesel::pg::Pg))` adds additional compile time checks to verify that all field types in 
+`#[diesel(check_for_backend(diesel::pg::Pg))` (or `sqlite::SQLite` or `mysql::MySQL`) adds additional compile time checks to verify that all field types in 
 your struct are compatible with their corresponding SQL side expressions. This part is optional, but it greatly improves
 the generated compiler error messages.
 
@@ -729,7 +746,6 @@ Using `#[derive(Selectable)]` in combination with [`SelectableHelper::as_select`
 
 Let's write the code to actually show us our posts.
 
-<!-- This example is the same across PostgrSQL, SQLite, and MySQL -->
 ::: code-block
 [src/bin/show_posts.rs](https://github.com/diesel-rs/diesel/blob/2.2.x/examples/postgres/getting_started_step_1/src/bin/show_posts.rs)
 


### PR DESCRIPTION
Hi, I followed your getting started guide earlier using SQLite (and thank you--it successfully got me started!), and I agreed with issue #130. 

I put together some javascript to show the blocks of code for the examples using different databases. This is not quite as nice as the mock up in that issue, but the code-blocks seemed like they would be more complicated to add buttons to. Let me know if you think that (or anything else) should work differently and I can try to fix it.

The code examples I added were all copied and pasted out of [here](https://github.com/diesel-rs/diesel/tree/v1.4.4/examples). Any examples that were exactly the same across the 3 databases I just left as they were and they still link to the PostgreSQL on github since I didn't want to add 3 copies of the same code just to update the github link. If you think that should be more consistent I can take another look and maybe find some better way to update the link.

Some specific questions I guessed on for now but should be answered definitively if you want to merge this:

- Does [this example, step 1 lib.rs](https://github.com/diesel-rs/diesel/blob/2.2.x/examples/sqlite/getting_started_step_1/src/lib.rs) need to include the line `use diesel::sqlite::SqliteConnection;` (or in the others, PgConnection or MySQLConnection)? The current getting started example includes the line `use diesel::pg::PgConnection;`, but in the linked file on github that line is not included. It compiled and ran for me on SQLite without including that line.

- In the table macro example of schema.rs, does that actually vary by database type? I copied the generated schema.rs files from the examples, but I'm not sure if that is supposed to be different because it's not the auto-generated file. 

Example of the markdown format to make a new code block that has different code for the different database options:

~~~
::: postgres-example
::: code-block

[Cargo.toml](https://github.com/diesel-rs/diesel/blob/2.2.x/examples/postgres/getting_started_step_1/Cargo.toml)

```toml
[dependencies]
diesel = { version = "2.2.0", features = ["postgres"] }
dotenvy = "0.15"
```
:::
:::


::: sqlite-example
::: code-block 

[Cargo.toml (SQLite)](https://github.com/diesel-rs/diesel/blob/2.2.x/examples/sqlite/getting_started_step_1/Cargo.toml)

```toml
[dependencies]
diesel = { version = "2.2.0", features = ["sqlite"] }
dotenvy = "0.15"
```
:::
:::

::: mysql-example
::: code-block 

[Cargo.toml (MySQL)](https://github.com/diesel-rs/diesel/blob/2.2.x/examples/mysql/getting_started_step_1/Cargo.toml)

```toml
[dependencies]
diesel = { version = "2.2.0", features = ["mysql"] }
dotenvy = "0.15"
```
:::
:::
~~~