### PR TITLE
Correct English syntax errors and some other small issues.

### DIFF
--- a/src/compare_diesel.md
+++ b/src/compare_diesel.md
@@ -65,51 +65,51 @@ The `tokio-postgres`, `rusqlite`, and `mysql` crates belong to the first categor
 * `sqlx` requires a database running to perform the type-checks, although they also offer a mode that allows to read the relevant information from a previously dumped folder
 * `diesel` can also check parts of the query at compile time. This allows you to build dynamic compile time checked queries as well.
 
-Additionally there are differences in how exactly the type checking works. As `sqlx` relies on the database to provide type and correctness information it needs to work with these databases provide. These result widely varies between database systems and is often incomplete. A rather famous example here is the inference of the nullability of values coming from a left join. `sqlx` cannot infer that such a column might be actually `NULL` if it's marked as `NOT NULL` in your schema due to restrictions what these database return. `diesel` on the other hand can infer this information as it brings it's own type checking. On the other hand `diesel`'s approach has the downside that it needs to model all the relevant information in the type system, which opens up room for slight differences to the behaviour of the supported databases. At the time of writing the author is not aware of any such difference, but they could exist.
+Additionally there are differences in how exactly the type checking works. As `sqlx` relies on the database to provide type and correctness information, it needs to work with what these databases provide. These results widely varies between database systems and are often incomplete. A rather famous example here is the inference of the nullability of values coming from a left join. `sqlx` cannot infer that such a column might be actually `NULL` if it's marked as `NOT NULL` in your schema due to restrictions what these databases return. `diesel` on the other hand can infer this information as it brings its own type checking. On the other hand `diesel`'s approach has the downside that it needs to model all the relevant information in the type system, which opens up room for slight differences to the behaviour of the supported databases. At the time of writing the author is not aware of any such differences, but they could exist.
 
-Overall, both `diesel` and `sqlx` provide compile time checking, but the extend and correctness of this checking widely differs. `diesel`'s checking is much more extensive and robust compared to what is currently implemented by `sqlx`.
+Overall, both `diesel` and `sqlx` provide compile time checking, but the extent and correctness of this checking widely differs. `diesel`'s checking is much more extensive and robust compared to what is currently implemented by `sqlx`.
 
 ## Flexibility
 
-All listed crates expose an API that just let's you pass in string and a number of rust side values (via bind parameters). From that point of view every crate can express any possible SQL query. The main question here is rather: Which queries can be supported by using the safest possible API offered by this crate?
+All listed crates expose an API that just lets you pass in string and a number of Rust-side values (via bind parameters). From that point of view every crate can express any possible SQL query. The main question here is rather: Which queries can be supported by using the safest possible API offered by this crate?
 
-For the `tokio-postgres`, `rusqlite` and `mysql` crate this is simple to answer as the safest API is at the same time the API that lets you pass in a string and an number of bind values. So by definition it can execute any SQL query.
+For the `tokio-postgres`, `rusqlite` and `mysql` crates this is simple to answer as the safest API is at the same time the API that lets you pass in a string and a number of bind values. So by definition it can execute any SQL query.
 
-For `sea-orm` this API is their query builder, which obviously restricts the amount of supported queries by that DSL. At the time of writing this covers most common SQL functionality supported by PostgreSQL, SQLite and MySQL, which excludes most database specific features like for json operators or other functionality for database specific types. Notably it currently excludes the possibility to join more than 3 tables at the same time using their model based API. It's possible to express such joins using their query builder instead. Crucially `sea-orm` also does not offer any extension points to extend their built-in DSL so you can bring your own drop in replacement for missing functionality. It is possible to write dynamic queries using the exposed query builder.
+For `sea-orm` this API is their query builder, which obviously restricts the amount of supported queries by that DSL. At the time of writing this covers most common SQL functionality supported by PostgreSQL, SQLite and MySQL, which excludes most database specific features, such as JSON operators or other functionality for database-specific types. Notably it currently excludes the possibility to join more than 3 tables at the same time using their model-based API. It's possible to express such joins using their query builder instead. Crucially `sea-orm` also does not offer any extension points to extend their built-in DSL so you can bring your own drop in replacement for missing functionality. It is possible to write dynamic queries using the exposed query builder.
 
-`sqlx` allows you to express any at **compile time statically known** query via their macros. On the one hand this covers a large amount of possible SQL queries, on the other hand this excludes any query that might possibly on runtime information. This includes the following possible queries:
+`sqlx` allows you to express any at **compile time statically known** query via their macros. On the one hand this covers a large amount of possible SQL queries, on the other hand this excludes any query that might possibly rely on runtime information. This includes the following possible queries:
 
-* Anything that involves an `IN` expression that is constructed from a Rust side vector of values
-* Any possible form of batch insert statements that again depend on a vector of values on Rust side
-* Any possible query that might want to add a condition depending on a Rust side condition
+* Anything that involves an `IN` expression that is constructed from a Rust-side vector of values
+* Any possible form of batch insert statements that again depend on a vector of values on the Rust-side
+* Any possible query that might want to add a condition depending on a Rust-side condition
 
 In the opinion of the author of this document these cases are not that uncommon in real world applications. By not using the static query checking in these cases you essentially lose all benefits of `sqlx` there and fall back to the same level of functionality offered by `tokio-postgres`, `mysql` and `rusqlite`
 
-`diesel` allows you to check any query expressible by the built-in DSL or any DSL/your own extension. This includes most dynamic queries, as long as at least the `FROM` query of your query is known at compile time. At the time of writing the built-in `diesel` DSL covers almost all common SQL supported by any of the supported backend, including many database specific types/operations/functions. There are SQL constructs that are currently unsupported by diesel. This includes:
+`diesel` allows you to check any query expressible by the built-in DSL or any DSL/your own extension. This includes most dynamic queries, as long as at least the `FROM` query of your query is known at compile time. At the time of writing the built-in `diesel` DSL covers almost all common SQL supported by any of the supported backends, including many database-specific types/operations/functions. There are SQL constructs that are currently unsupported by diesel. These include:
 
 * Common table expressions
 * Subqueries as `FROM` clause
 
-While it's possible to write custom extensions to for all of these missing variants, it can be challenging to do that in a way that provides the same level of compile time checks as other parts of diesel.
+While it's possible to write custom extensions for all of these missing variants, it can be challenging to do that in a way that provides the same level of compile time checks as other parts of diesel.
 
 ## Extensibility
 
 Extensibility is mostly important for crates providing additional functionality on top of just executing queries or which support more than one database, which makes this topic relevant for `sea-orm`, `sqlx` and `diesel`.
 
-`sea-orm` models most of their DSL as structs and enums. These have only the specified set of fields/variants. Given that for example expressions are implemented as enum this makes it impossible to easily provide your own custom expression operator that is not supported yet by `sea-orm`. The same goes for the supported database backends, which is an enum as well. Again this makes it impossible to extend the set of supported backends outside of `sea-orm`.
+`sea-orm` models most of their DSL as structs and enums. These have only the specified set of fields/variants. Given that for example expressions are implemented as enums this makes it impossible to easily provide your own custom expression operator that is not supported yet by `sea-orm`. The same goes for the supported database backends, which is an enum as well. Again this makes it impossible to extend the set of supported backends outside of `sea-orm`.
 
-`sqlx` heavily relies on proc-macros for it's core functionality. As far as the author of this document knows it is not possible to extend a proc-macro crate, without providing an entirely new crate that reimplements/rexports the other proc-macro. This makes it essentially impossible to extend the set of database backends supported by `sqlx`.
+`sqlx` heavily relies on proc-macros for its core functionality. As far as the author of this document knows it is not possible to extend a proc-macro crate, without providing an entirely new crate that reimplements/rexports the other proc-macro. This makes it essentially impossible to extend the set of database backends supported by `sqlx`.
 
-`diesel` heavily relies on traits for almost anything. On of the large upsides of this approach is that you can extend almost anything in `diesel`, including the DSL, the type mapping and the set of supported backends. You can find examples for this on crates.io:
+`diesel` heavily relies on traits for almost everything. One of the large upsides of this approach is that you can extend almost anything in `diesel`, including the DSL, the type mapping and the set of supported backends. You can find examples for this on crates.io:
 
 * [postgis-diesel](https://crates.io/crates/postgis_diesel) Support for the PostGIS extension (Functions & Types)
 * [pgvector](https://crates.io/crates/pgvector) Support for the PgVector extension (Functions & Types)
-* [diesel-oracle](https://crates.io/crates/diesel-oci) Support for Oracle as custom backend
+* [diesel-oracle](https://crates.io/crates/diesel-oci) Support for Oracle as a custom backend
 
 
 ## Usability
 
-The `diesel-async` crate(not with the sqlite backend), the `sqlx` crate (not with the sqlite backend), the `sea-orm` crate (not with the sqlite backend), the `tokio-postgres` crate, the `postgres`, the `mysql-async` and the `mysql` crate provide pure rust connection implementations. This makes the first compilation of these crates as easy as running `cargo build`. They don't require any additional dependencies.
+The `diesel-async` crate (not with the sqlite backend), the `sqlx` crate (not with the sqlite backend), the `sea-orm` crate (not with the sqlite backend), the `tokio-postgres` crate, the `postgres`, the `mysql-async` and the `mysql` crate provide pure Rust connection implementations. This makes the first compilation of these crates as easy as running `cargo build`. They don't require any additional dependencies.
 `diesel`, `rusqlite` and any other crate with a sqlite backend have dependencies on the native C client libraries for the relevant databases. These need to be installed before compiling these crates, although there are also ways to compile them as part of your build process. This can make the first compilation harder.
 
 All of `diesel`, `diesel-async` and `sqlx` rely on traits to implement core parts of their functionality. While this makes things very flexible it can also lead to hard to understand error messages with these crates. `diesel` (and `diesel-async`) provide [documentation](https://docs.diesel.rs/2.2.x/diesel/index.html#how-to-read-diesels-compile-time-error-messages) on how to read error messages. Additionally it provides helper attributes and employs compiler hints to improve possible error messages to make them easier to understand.
@@ -117,7 +117,7 @@ All of `diesel`, `diesel-async` and `sqlx` rely on traits to implement core part
 
 ## Performance
 
-Performance is a complicated topic. It can be noted that all of the listed crates provide an good performance for almost all use-cases, as most users do not really need to care about the last bit of possible performance. Nevertheless there are differences in the performance provided by the different crates. As always: If you need to care about performance make sure to perform your **own** benchmarks with your own workload to find the optimal solution for your use-case. The following text will provide an general overview.
+Performance is a complicated topic. It can be noted that all of the listed crates provide good performance for almost all use-cases, as most users do not really need to care about the last bit of possible performance. Nevertheless there are differences in the performance provided by the different crates. As always: If you need to care about performance make sure to perform your **own** benchmarks with your own workload to find the optimal solution for your use-case. The following text will provide a general overview.
 [The Diesel benchmark repository](https://github.com/diesel-rs/metrics) provides an overview of different benchmark results for all listed crates. 
 We can observe the following points:
 
@@ -138,7 +138,7 @@ In the context of performance there are often claims that async database drivers
 * SQLite provides a purely synchronous API, any async library build on top of it introduces additional overhead
 * Simple SQLite queries can stay under the 10 to 100 microseconds limit of what is [commonly considered as blocking in Rust](https://ryhl.io/blog/async-what-is-blocking/)
 (See the benchmark repository for examples)
-* For network based database services like PostgreSQL and MySQL your application is usually limited by the number of database connection. These database systems commonly allow only a few ten connections (up to the low hundreds) of database connections before running out of resources. If your application receives more concurrent requests than this it will need to wait on *getting* a database connection. This use-case is covered by async database pool solutions like [deadpool-diesel](https://docs.rs/deadpool-diesel/latest/deadpool_diesel/index.html), which can be used in combination with synchronous database libraries.
+* For network-based database services like PostgreSQL and MySQL your application is usually limited by the number of database connection. These database systems commonly allow only a few ten connections (up to the low hundreds) of database connections before running out of resources. If your application receives more concurrent requests than this it will need to wait on *getting* a database connection. This use-case is covered by async database pool solutions like [deadpool-diesel](https://docs.rs/deadpool-diesel/latest/deadpool_diesel/index.html), which can be used in combination with synchronous database libraries.
 
 That all written: There are valid use-cases for using an async database library, for example setups with high network latency or situations where you need to abort requests. You can cover this use-case with [diesel-async](https://lib.rs/crates/diesel-async).
 


### PR DESCRIPTION
Fixes obvious syntax errors, incorrect uses of `let's`, `it's` and `an`. Also fixes some capitalization inconsistencies and plurality mismatches.

I didn't add or remove any commas because this is often a matter of writing style and opinion that I'm not interested in debating.