### PR TITLE
Update generated migration aside for getting started guide

### DIFF
--- a/src/guides/getting-started.md
+++ b/src/guides/getting-started.md
@@ -429,8 +429,7 @@ diesel::table! {
 * Run `diesel migration generate --diff-schema create_posts`
 
 This will generate both the `up.sql` and the `down.sql` files of your migration pre-populated with the relevant SQL.
-Note that, for this example, the migration generated from the schema does not add a `DEFAULT` attribute for the `published` field, so you'll have to add it yourself for
-the rest of this example to work. After that, you should continue with the `diesel migration run` step.
+These pre-populated migration files can serve as starting point to adjust the generated SQL to your needs. You as as user need to decide which modifications are relevant for your use case as Diesel will never generate a completly perfect migration for you. For this guide for example you need to add a `DEFAULT` clause to the `published` field to match the migration shown earlier.
 :::
 </aside>
 


### PR DESCRIPTION
Fixes #253

Currently, in the getting started guide, the aside about generating the migrations from schema doesn't mention that you need to add a `DEFAULT` property to the generated SQL migrations. If following along with the guide, this results in a runtime error later in the guide (when running the post creation code). In the aside talking about generating these migrations, it implies that you can follow along the rest of the guide after generating these migrations, so this change gives the instructions needed to follow along.