### PR TITLE
Fix heading nesting in many-to-many section of relations guide

### DIFF
--- a/src/content/docs/guides/relations.md
+++ b/src/content/docs/guides/relations.md
@@ -398,7 +398,7 @@ concept of `has_many` but instead we are going create a "join table"
 `books_authors` and add a `belongs_to` to both `books` and `authors`. Let's see
 that in action.
 
-## Migrations
+### Migrations
 <br />
 
 ```sh
@@ -457,7 +457,7 @@ diesel migration redo -n 2
 ```
 
 
-## Model
+### Model
 <br />
 
 Now let's reflect the join table in the `model.rs`. To keep this brief, let's only look at what we are adding.
@@ -491,7 +491,7 @@ pub struct BookAuthor {
 
 The important part is to give `BooksAuthor` two `belongs_to` that point to the book and the author.
 
-## Reading data
+### Reading data
 <br />
 
 If we now want to load all books of a given author we can combine joins and diesels `BelongingToDsl` to load these data:


### PR DESCRIPTION
## Summary
- The Migrations, Model, and Reading data sub-headings under the many-to-many section were using `##` (same level as the parent `## many-to-many or m:n`), causing them to render as sibling sections rather than nested children.
- Changed them to `###` so they nest correctly under the m:n heading.

## Test plan
- [ ] Verify the relations guide renders with correct heading hierarchy on the docs site