### PR TITLE
Add SQLite-specific features guide

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -46,6 +46,7 @@ export default defineConfig({
 						{ label: 'Relations', link: '/guides/relations/' },
 						{ label: 'Composing Applications with Diesel', link: '/guides/composing-applications/' },
 						{ label: 'Schema in Depth', link: '/guides/schema-in-depth/' },
+						{ label: 'SQLite-specific features', link: '/guides/sqlite-features/' },
 						{ label: 'Extending Diesel', link: '/guides/extending-diesel/' },
 						{ label: 'Configuring Diesel CLI', link: '/guides/configuring-diesel-cli/' },
 						{ label: 'Diesel 2.0 migration guide', link: '/guides/migration-guide/' },

--- a/public/images/sqlite_db_config.svg
+++ b/public/images/sqlite_db_config.svg
@@ -1,0 +1,132 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 473">
+  <defs>
+    <style>
+      .title { font: bold 16px sans-serif; fill: #1a1a2e; }
+      .subtitle { font: 11px sans-serif; fill: #4a4a6a; }
+      .section { font: bold 12px sans-serif; }
+      .label { font: bold 11px sans-serif; }
+      .method { font: bold 9px monospace; fill: #455a64; }
+      .desc { font: 9px sans-serif; fill: #555; }
+      .date { font: 8px sans-serif; fill: #999; }
+    </style>
+  </defs>
+
+  <rect width="940" height="473" fill="#fafafa"/>
+
+  <text x="470" y="16" text-anchor="middle" class="title">SQLite db_config Connection Settings</text>
+  <text x="470" y="30" text-anchor="middle" class="subtitle">Per-connection runtime settings. These do NOT persist — set them each time you open a connection.</text>
+
+  <!-- ALL OPERATIONS -->
+  <rect x="5" y="38" width="930" height="415" rx="8" fill="#e3f2fd" stroke="#1976d2" stroke-width="2"/>
+  <text x="15" y="54" class="section" fill="#0d47a1">ALL SQL OPERATIONS</text>
+
+  <!-- Top row -->
+  <rect x="12" y="62" width="300" height="105" rx="6" fill="#bbdefb" stroke="#1976d2" stroke-width="1.5"/>
+  <text x="20" y="77" class="label" fill="#0d47a1">DDL Statements (always allowed)</text>
+  <foreignObject x="20" y="80" width="284" height="83">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font: 9px sans-serif; color: #333; line-height: 1.3;">
+      <p style="margin: 0 0 4px 0; color: #555;"><b>DDL = Data Definition Language:</b> Commands that modify the database schema itself, not the data.</p>
+      <p style="margin: 0 0 4px 0; color: #555;">Examples: <span style="font-family: monospace; color: #1565c0;">CREATE TABLE</span>, <span style="font-family: monospace; color: #1565c0;">ALTER TABLE</span>, <span style="font-family: monospace; color: #1565c0;">DROP INDEX</span>, <span style="font-family: monospace; color: #1565c0;">CREATE VIEW</span></p>
+      <p style="margin: 0; color: #666; font-style: italic;">db_config cannot block DDL. Use <span style="font-family: monospace;">conn.on_authorize()</span> callback to intercept and reject specific DDL commands.</p>
+    </div>
+  </foreignObject>
+
+  <rect x="320" y="62" width="300" height="105" rx="6" fill="#ffebee" stroke="#c62828" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <text x="328" y="77" class="label" fill="#b71c1c">DEFENSIVE MODE (default: off)</text>
+  <text x="328" y="89" class="method">set_defensive(true)</text>
+  <foreignObject x="328" y="92" width="284" height="71">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font: 9px sans-serif; color: #333; line-height: 1.3;">
+      <p style="margin: 0 0 3px 0; color: #555;">Blocks dangerous low-level operations that bypass normal SQL and could corrupt the database:</p>
+      <p style="margin: 0; color: #c62828; font-size: 8px;">• <b>PRAGMA writable_schema</b>: direct edits to sqlite_master table<br/>• <b>Shadow table writes</b>: internal tables for FTS5/R-Tree<br/>• <b>Unsafe deserialize</b>: loading raw database images into memory</p>
+    </div>
+  </foreignObject>
+
+  <rect x="628" y="62" width="300" height="105" rx="6" fill="#eceff1" stroke="#607d8b" stroke-width="1.5"/>
+  <text x="636" y="77" class="label" fill="#455a64">LOAD EXTENSION (default: off)</text>
+  <text x="636" y="89" class="method">with_load_extension_enabled()</text>
+  <foreignObject x="636" y="92" width="284" height="71">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font: 9px sans-serif; color: #333; line-height: 1.3;">
+      <p style="margin: 0 0 3px 0; color: #555;">SQLite can load C extensions (.so/.dll) at runtime via <span style="font-family: monospace; color: #1565c0;">SELECT load_extension('path')</span>.</p>
+      <p style="margin: 0 0 3px 0; color: #555;">This is a <b>runtime flag only</b>. SQLite must also be compiled <b>without</b> <span style="font-family: monospace; font-size: 8px;">SQLITE_OMIT_LOAD_EXTENSION</span> for this to work.</p>
+      <p style="margin: 0; color: #c62828; font-size: 8px;">Security risk: extensions run native code. Keep off unless you need it.</p>
+    </div>
+  </foreignObject>
+
+  <!-- SCHEMA OBJECTS -->
+  <rect x="12" y="175" width="916" height="270" rx="8" fill="#fff8e1" stroke="#ff8f00" stroke-width="2"/>
+  <text x="20" y="191" class="section" fill="#e65100">SCHEMA OBJECTS</text>
+  <text x="150" y="191" class="desc">"Schema objects" are SQL code stored inside the database file itself. They execute automatically — you don't call them directly.</text>
+
+  <!-- Row 1 -->
+  <rect x="20" y="199" width="295" height="115" rx="6" fill="#ffe0b2" stroke="#f57c00" stroke-width="1"/>
+  <text x="28" y="214" class="label" fill="#e65100">VIEWS (default: on)</text>
+  <text x="28" y="226" class="method">set_views_enabled()</text>
+  <foreignObject x="28" y="229" width="279" height="81">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font: 9px sans-serif; color: #333; line-height: 1.3;">
+      <p style="margin: 0 0 4px 0; color: #555;"><b>Views</b> are saved SELECT queries. When you query a view, SQLite runs the underlying SELECT.</p>
+      <p style="margin: 0 0 4px 0; color: #555;">Example: <span style="font-family: monospace; font-size: 8px; color: #1565c0;">CREATE VIEW active_users AS SELECT * FROM users WHERE active=1</span></p>
+      <p style="margin: 0;"><span style="color: #1565c0;">true:</span> views work normally · <span style="color: #c62828;">false:</span> any query touching a view returns an error</p>
+    </div>
+  </foreignObject>
+
+  <rect x="323" y="199" width="295" height="115" rx="6" fill="#f3e5f5" stroke="#8e24aa" stroke-width="1"/>
+  <text x="331" y="214" class="label" fill="#6a1b9a">TRIGGERS (default: on)</text>
+  <text x="331" y="226" class="method">set_triggers_enabled()</text>
+  <foreignObject x="331" y="229" width="279" height="81">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font: 9px sans-serif; color: #333; line-height: 1.3;">
+      <p style="margin: 0 0 4px 0; color: #555;"><b>Triggers</b> are SQL code that runs automatically when data changes (INSERT, UPDATE, DELETE).</p>
+      <p style="margin: 0 0 4px 0; color: #555;">Common uses: audit logs, maintaining denormalized data, enforcing business rules, cascading updates.</p>
+      <p style="margin: 0;"><span style="color: #1565c0;">true:</span> triggers fire on data changes · <span style="color: #c62828;">false:</span> triggers are silently skipped</p>
+    </div>
+  </foreignObject>
+
+  <rect x="626" y="199" width="295" height="115" rx="6" fill="#e0f2f1" stroke="#00897b" stroke-width="1"/>
+  <text x="634" y="214" class="label" fill="#00695c">CHECK / DEFAULT / GENERATED</text>
+  <foreignObject x="634" y="220" width="279" height="90">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font: 9px sans-serif; color: #333; line-height: 1.3;">
+      <p style="margin: 0 0 3px 0; color: #555;"><b>CHECK:</b> validation expressions, e.g. <span style="font-family: monospace; font-size: 8px; color: #1565c0;">CHECK(age &gt;= 0 AND age &lt; 150)</span></p>
+      <p style="margin: 0 0 3px 0; color: #555;"><b>DEFAULT:</b> value used when INSERT omits a column, e.g. <span style="font-family: monospace; font-size: 8px; color: #1565c0;">DEFAULT CURRENT_TIMESTAMP</span></p>
+      <p style="margin: 0 0 4px 0; color: #555;"><b>GENERATED:</b> computed columns, e.g. <span style="font-family: monospace; font-size: 8px; color: #1565c0;">full_name AS (first || ' ' || last)</span></p>
+      <p style="margin: 0; font-style: italic; color: #666; font-size: 8px;">These cannot be disabled. To skip CHECK: <span style="font-family: monospace;">PRAGMA ignore_check_constraints=ON</span></p>
+    </div>
+  </foreignObject>
+
+  <!-- Row 2 -->
+  <rect x="20" y="322" width="295" height="115" rx="6" fill="#e3f2fd" stroke="#1976d2" stroke-width="1"/>
+  <text x="28" y="337" class="label" fill="#1565c0">FOREIGN KEYS (default: OFF!)</text>
+  <text x="28" y="349" class="method">set_foreign_keys_enabled()</text>
+  <foreignObject x="28" y="352" width="279" height="81">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font: 9px sans-serif; color: #333; line-height: 1.3;">
+      <p style="margin: 0 0 4px 0; color: #555;"><b>Foreign keys</b> enforce referential integrity: child rows must reference existing parent rows.</p>
+      <p style="margin: 0 0 4px 0; color: #c62828;"><b>⚠ SQLite disables foreign keys by default!</b> This surprises many developers. You must enable them explicitly on each connection.</p>
+      <p style="margin: 0;"><span style="color: #1565c0;">true:</span> orphaned references cause ERROR · <span style="color: #666;">false:</span> orphans silently allowed</p>
+    </div>
+  </foreignObject>
+
+  <rect x="323" y="322" width="295" height="115" rx="6" fill="#efebe9" stroke="#8d6e63" stroke-width="1"/>
+  <text x="331" y="337" class="label" fill="#5d4037">DOUBLE-QUOTED STRINGS (default: on)</text>
+  <text x="331" y="349" class="method">set_double_quoted_strings_dml() / _ddl()</text>
+  <foreignObject x="331" y="352" width="279" height="81">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font: 9px sans-serif; color: #333; line-height: 1.3;">
+      <p style="margin: 0 0 4px 0; color: #555;"><b>Standard SQL:</b> double quotes = identifier (column/table name), single quotes = string literal.</p>
+      <p style="margin: 0 0 4px 0; color: #555;"><b>SQLite legacy quirk:</b> <span style="font-family: monospace; color: #1565c0;">"hello"</span> is treated as string <span style="font-family: monospace;">'hello'</span> if no column named "hello" exists.</p>
+      <p style="margin: 0;"><span style="color: #1565c0;">true:</span> legacy behavior · <span style="color: #c62828;">false:</span> strict SQL (recommended for new code)</p>
+    </div>
+  </foreignObject>
+
+  <rect x="626" y="322" width="295" height="115" rx="6" fill="#fffde7" stroke="#fbc02d" stroke-width="1"/>
+  <text x="634" y="337" class="label" fill="#f57f17">TRUSTED SCHEMA (default: on)</text>
+  <text x="634" y="349" class="method">set_trusted_schema()</text>
+  <foreignObject x="634" y="352" width="279" height="81">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font: 9px sans-serif; color: #333; line-height: 1.3;">
+      <p style="margin: 0 0 4px 0; color: #555;">Controls which <b>custom SQL functions</b> (registered via Diesel) can be called from schema objects like views and triggers.</p>
+      <p style="margin: 0 0 4px 0; color: #555;"><span style="color: #1565c0;">true:</span> most functions allowed (trust the database schema)</p>
+      <p style="margin: 0 0 4px 0; color: #c62828;"><span style="color: #c62828;">false:</span> only functions marked INNOCUOUS (for untrusted .db files)</p>
+      <p style="margin: 0; font-style: italic; color: #666; font-size: 8px;">See sqlite_function_flags.svg for details on function flags.</p>
+    </div>
+  </foreignObject>
+
+  <!-- Legend and date -->
+  <text x="5" y="465" class="desc">Dashed border = orthogonal security restriction. All db_config settings are per-connection and must be set after opening the connection.</text>
+  <text x="935" y="465" text-anchor="end" class="date">2026-02-14</text>
+</svg>

--- a/public/images/sqlite_function_flags.svg
+++ b/public/images/sqlite_function_flags.svg
@@ -1,0 +1,106 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 450">
+  <defs>
+    <style>
+      .title { font: bold 16px sans-serif; fill: #1a1a2e; }
+      .subtitle { font: 11px sans-serif; fill: #4a4a6a; }
+      .section { font: bold 12px sans-serif; }
+      .label { font: bold 11px sans-serif; }
+      .method { font: bold 9px monospace; fill: #455a64; }
+      .flag { font: bold 10px monospace; }
+      .desc { font: 9px sans-serif; fill: #555; }
+      .date { font: 8px sans-serif; fill: #999; }
+    </style>
+  </defs>
+
+  <rect width="900" height="450" fill="#fafafa"/>
+
+  <text x="450" y="16" text-anchor="middle" class="title">SQLite Function Behavior Flags</text>
+  <text x="450" y="30" text-anchor="middle" class="subtitle">When you register a custom SQL function in Diesel, these flags control WHERE that function can be called from.</text>
+
+  <!-- DIRECT SQL -->
+  <rect x="5" y="38" width="890" height="392" rx="8" fill="#e3f2fd" stroke="#1976d2" stroke-width="2"/>
+  <text x="15" y="54" class="section" fill="#0d47a1">DIRECT SQL QUERIES</text>
+  <text x="175" y="54" class="desc">SQL you execute directly from your application code. All functions work here, regardless of flags.</text>
+
+  <!-- DIRECTONLY box -->
+  <rect x="12" y="62" width="430" height="88" rx="6" fill="#bbdefb" stroke="#1976d2" stroke-width="1.5"/>
+  <text x="20" y="77" class="flag" fill="#0d47a1">DIRECTONLY</text>
+  <foreignObject x="20" y="80" width="414" height="66">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font: 9px sans-serif; color: #333; text-align: justify; line-height: 1.3;">
+      <p style="margin: 0 0 4px 0; color: #555;">Mark functions with <b>DIRECTONLY</b> when they have <b>side effects</b> or expose <b>sensitive application state</b>. These functions can ONLY be called from your application code — never from views, triggers, or other schema objects.</p>
+      <p style="margin: 0; color: #555;">Examples: logging functions, audit trails, network calls, file I/O, functions that read application config.</p>
+    </div>
+  </foreignObject>
+
+  <!-- Flag reference -->
+  <rect x="450" y="62" width="438" height="88" rx="6" fill="#fff" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="456" y="77" class="label" fill="#333">Flag Reference (SqliteFunctionBehavior)</text>
+  <foreignObject x="454" y="80" width="430" height="66">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font: 9px sans-serif; color: #333; line-height: 1.3;">
+      <table style="width: 100%; border-collapse: collapse;">
+        <tr><td style="font: bold 9px monospace; color: #0d47a1; width: 85px; vertical-align: top;">DIRECTONLY</td><td style="color: #555;">Function can ONLY run from your app code, never from schema objects</td></tr>
+        <tr><td style="font: bold 9px monospace; color: #e65100; vertical-align: top;">DETERMINISTIC</td><td style="color: #555;">Same inputs always produce same output. Lets SQLite cache results and optimize.</td></tr>
+        <tr><td style="font: bold 9px monospace; color: #1b5e20; vertical-align: top;">INNOCUOUS</td><td style="color: #555;">Safe to call from untrusted schemas. No side effects, no secrets. Required for hardened mode.</td></tr>
+        <tr><td style="font: bold 9px monospace; color: #616161; vertical-align: top;">SUBTYPE</td><td style="color: #555;">Function inspects JSON subtypes via sqlite3_value_subtype(). Rarely needed.</td></tr>
+      </table>
+    </div>
+  </foreignObject>
+
+  <!-- SCHEMA OBJECTS -->
+  <rect x="12" y="158" width="876" height="264" rx="8" fill="#fff8e1" stroke="#ff8f00" stroke-width="2"/>
+  <text x="20" y="174" class="section" fill="#e65100">SCHEMA OBJECTS</text>
+  <text x="150" y="174" class="desc">Code stored in the database file: Views, Triggers, CHECK constraints, DEFAULT expressions, Generated columns. When someone opens your .db file, this code runs automatically.</text>
+
+  <!-- TRUSTED MODE -->
+  <rect x="20" y="182" width="424" height="232" rx="6" fill="#fff9c4" stroke="#f9a825" stroke-width="1.5"/>
+  <text x="28" y="198" class="label" fill="#f57f17">TRUSTED MODE (default)</text>
+  <text x="28" y="210" class="method">set_trusted_schema(true)</text>
+  <foreignObject x="28" y="214" width="408" height="194">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font: 9px sans-serif; color: #333; line-height: 1.35;">
+      <p style="margin: 0 0 6px 0; color: #555;"><b>Use when:</b> You created this database yourself, or you trust whoever gave it to you. The schema (views, triggers, etc.) won't try to exploit your custom functions.</p>
+
+      <p style="margin: 0 0 2px 0; color: #2e7d32;"><b>Functions allowed in schema objects:</b></p>
+      <p style="margin: 0 0 6px 0; color: #2e7d32;">
+        ✓ <b>DETERMINISTIC</b> — pure functions like upper(), abs()<br/>
+        ✓ <b>(no flags)</b> — non-deterministic like random(), uuid()<br/>
+        ✓ <b>INNOCUOUS</b> — explicitly safe functions
+      </p>
+
+      <p style="margin: 0 0 6px 0; color: #c62828;">✗ <b>DIRECTONLY</b> — always blocked in schema objects, even in trusted mode</p>
+
+      <p style="margin: 0 0 4px 0; font-family: monospace; font-size: 8px; color: #1565c0;">-- This view can call your custom upper_case() function:<br/>CREATE VIEW v AS SELECT upper_case(name) FROM users;</p>
+
+      <p style="margin: 0; font-style: italic; color: #666;">Tip: If you plan to harden later, add INNOCUOUS flag to your functions now.</p>
+    </div>
+  </foreignObject>
+
+  <!-- HARDENED MODE -->
+  <rect x="452" y="182" width="428" height="232" rx="6" fill="#c8e6c9" stroke="#2e7d32" stroke-width="2"/>
+  <text x="460" y="198" class="label" fill="#1b5e20">HARDENED MODE</text>
+  <text x="460" y="210" class="method">set_trusted_schema(false)</text>
+  <foreignObject x="460" y="214" width="412" height="194">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font: 9px sans-serif; color: #333; line-height: 1.35;">
+      <p style="margin: 0 0 6px 0; color: #555;"><b>Use when:</b> Opening a .db file you didn't create. A malicious database could contain views/triggers designed to call your functions in harmful ways — e.g., a trigger that calls your logging function to leak data.</p>
+
+      <p style="margin: 0 0 2px 0; color: #2e7d32;"><b>Functions allowed in schema objects:</b></p>
+      <p style="margin: 0 0 6px 0; color: #2e7d32;">
+        ✓ <b>INNOCUOUS</b> — explicitly marked as safe<br/>
+        ✓ <b>INNOCUOUS + DETERMINISTIC</b> — safe and cacheable
+      </p>
+
+      <p style="margin: 0 0 6px 0; color: #c62828;">
+        ✗ <b>DETERMINISTIC alone</b> — not enough, needs INNOCUOUS<br/>
+        ✗ <b>(no flags)</b> — blocked<br/>
+        ✗ <b>DIRECTONLY</b> — always blocked
+      </p>
+
+      <p style="margin: 0 0 4px 0; font-family: monospace; font-size: 8px; color: #c62828;">-- If this view calls a non-INNOCUOUS function:<br/>SELECT * FROM malicious_view; -- ERROR!</p>
+
+      <p style="margin: 0; font-style: italic; color: #666;">INNOCUOUS = "this function is harmless even if called by untrusted code"</p>
+    </div>
+  </foreignObject>
+
+  <!-- Legend and date -->
+  <text x="5" y="442" class="desc">Inner boxes = more restricted execution contexts. INNOCUOUS is the key flag for security. For most pure functions, use DETERMINISTIC | INNOCUOUS.</text>
+  <text x="895" y="442" text-anchor="end" class="date">2026-02-14</text>
+</svg>

--- a/src/content/docs/guides/index.md
+++ b/src/content/docs/guides/index.md
@@ -33,6 +33,10 @@ This guide covers how to structure your application, and best practices for reus
 Ever wondered what exactly diesel print-schema and table! are doing?
 This guide will walk you through exactly what code gets generated, and how it's done.
 
+#### [SQLite-specific features](/guides/sqlite-features)
+
+Diesel exposes SQLite-only methods on `SqliteConnection` for hardening a connection against untrusted database files, tuning resource limits, registering custom SQL functions with explicit behavior flags, and applying configuration to every connection in your process.
+
 #### [Extending Diesel](/guides/extending-diesel)
 
 Want to use a feature Diesel doesn't support? Have a user defined SQL function?

--- a/src/content/docs/guides/sqlite-features.md
+++ b/src/content/docs/guides/sqlite-features.md
@@ -1,0 +1,241 @@
+---
+title: "SQLite-specific features"
+description: "Hardening and tuning a SqliteConnection with Diesel's SQLite-only methods for sqlite3_db_config, resource limits, custom SQL functions, and auto-extensions."
+lang: en-US
+---
+
+Diesel exposes a number of SQLite-only methods directly on
+[`SqliteConnection`](https://docs.diesel.rs/main/diesel/sqlite/struct.SqliteConnection.html).
+They let you harden a connection against untrusted database files, tune SQLite's
+built-in resource limits, register custom SQL functions with explicit behavior
+flags, and apply configuration to every connection opened in your process. This
+guide covers them together. Exact signatures live on the
+[`SqliteConnection` API page](https://docs.diesel.rs/main/diesel/sqlite/struct.SqliteConnection.html)
+and in the [`diesel::sqlite` module](https://docs.diesel.rs/main/diesel/sqlite/index.html).
+
+## Connection hardening with sqlite3_db_config
+
+SQLite exposes a family of per-connection switches through its
+[`sqlite3_db_config()`](https://www.sqlite.org/c3ref/db_config.html) C API. Diesel
+wraps the security-relevant ones as methods on `SqliteConnection`. The diagram
+below groups them by what they protect against.
+
+![Diesel SqliteConnection methods that wrap sqlite3_db_config, grouped by hardening concern](/images/sqlite_db_config.svg)
+
+### set_defensive
+
+This is the single most important hardening flag. Enabling defensive mode blocks
+writes to shadow tables, rejects a set of dangerous PRAGMAs, and prevents unsafe
+use of the deserialize interface. If you open database files you did not create,
+turn this on first.
+
+```rust
+conn.set_defensive(true)?;
+```
+
+### set_trusted_schema
+
+By default SQLite trusts the schema of the database it opens. Passing `false`
+restricts the functions that schema objects (views, triggers, CHECK constraints,
+DEFAULT expressions, generated columns, and expression indexes) are allowed to
+call to those explicitly marked `INNOCUOUS`. See the function flags section below
+for how to mark your own functions.
+
+```rust
+conn.set_trusted_schema(false)?;
+```
+
+### with_load_extension_enabled
+
+Loading SQLite extensions is a powerful capability and is disabled by default.
+Rather than leaving the `load_extension()` SQL function enabled for the lifetime
+of the connection, Diesel offers a scoped helper. The function is enabled for the
+duration of the closure and disabled again automatically when it returns, even on
+error.
+
+```rust
+conn.with_load_extension_enabled(|conn| {
+    diesel::sql_query("SELECT load_extension('my_extension')").execute(conn)
+})?;
+```
+
+Note that this toggles the `load_extension()` SQL function only. It does not call
+the `sqlite3_load_extension()` C API, which is a separate mechanism.
+
+Extension loading may also be unavailable at the build level. If your SQLite
+library was compiled with `SQLITE_OMIT_LOAD_EXTENSION`, the feature is omitted
+entirely and enabling it at runtime has no effect. This is common in hardened or
+minimal builds, so do not assume extension loading is available just because the
+runtime switch exists.
+
+### Double-quoted string literals
+
+For historical compatibility SQLite accepts double-quoted strings as string
+literals, which hides typos in identifiers and is a common source of bugs. You can
+turn this misfeature off independently for DML and DDL statements, and query the
+current state.
+
+```rust
+conn.set_double_quoted_strings_dml(false)?;
+conn.set_double_quoted_strings_ddl(false)?;
+
+assert!(!conn.are_double_quoted_strings_dml_enabled()?);
+assert!(!conn.are_double_quoted_strings_ddl_enabled()?);
+```
+
+### Other db_config switches
+
+The remaining switches follow the same pattern. Each takes a `bool` and returns a
+`QueryResult<()>`.
+
+- `set_fts3_tokenizer_enabled` controls the two-argument `fts3_tokenizer()`
+  function, which can be a code-execution vector.
+- `set_writable_schema` controls direct writes to `sqlite_schema`.
+- `set_attach_create_enabled` and `set_attach_write_enabled` control whether
+  `ATTACH` may create new files or attach writable databases.
+- `set_triggers_enabled` and `set_views_enabled` enable or disable triggers and
+  views entirely.
+- `set_foreign_keys_enabled` toggles foreign key enforcement.
+
+### Recommended recipe
+
+For most applications that may touch untrusted data, the following is a good
+baseline. Extension loading is already off by default, so enable it only when you
+need it via `with_load_extension_enabled`.
+
+```rust
+conn.set_defensive(true)?;
+conn.set_trusted_schema(false)?;
+conn.set_recommended_security_limits();
+```
+
+## Resource limits
+
+SQLite enforces a set of [run-time limits](https://www.sqlite.org/limits.html)
+such as the maximum length of a string or BLOB, the maximum length of an SQL
+statement, the number of columns in a table, and the depth of an expression tree.
+Diesel exposes these through `set_limit` and `get_limit`, keyed by the
+[`SqliteLimit`](https://docs.diesel.rs/main/diesel/sqlite/enum.SqliteLimit.html)
+enum.
+
+```rust
+use diesel::sqlite::SqliteLimit;
+
+let previous = conn.set_limit(SqliteLimit::SqlLength, 1_000_000);
+let current = conn.get_limit(SqliteLimit::SqlLength);
+```
+
+`SqliteLimit` covers length, SQL statement length, column count, expression depth,
+and several others. Rather than tuning each one by hand, you can call
+`set_recommended_security_limits`, which applies conservative defaults across the
+relevant limits in one call.
+
+```rust
+conn.set_recommended_security_limits();
+```
+
+## Custom SQL functions and behavior flags
+
+When you define a custom SQL function with
+[`#[declare_sql_function]`](https://docs.diesel.rs/main/diesel/expression/functions/attr.declare_sql_function.html),
+Diesel generates a helper module named after the function with a `_utils` suffix.
+That module contains the functions you use to register your implementation on a
+connection.
+
+- `register_impl` registers a deterministic implementation. It takes an `Fn`.
+- `register_nondeterministic_impl` registers a non-deterministic implementation.
+  It takes an `FnMut`, which is what you want for something like a random number
+  generator.
+- `register_impl_with_behavior` registers an implementation with explicit
+  behavior flags. It takes the connection, a `SqliteFunctionBehavior` value, and
+  the closure.
+
+```rust
+use diesel::expression::functions::declare_sql_function;
+use diesel::sql_types::Integer;
+
+#[declare_sql_function]
+extern "SQL" {
+    fn add_one(x: Integer) -> Integer;
+}
+
+// deterministic
+add_one_utils::register_impl(conn, |x: i32| x + 1)?;
+```
+
+The behavior flags come from
+[`SqliteFunctionBehavior`](https://docs.diesel.rs/main/diesel/sqlite/struct.SqliteFunctionBehavior.html),
+which is a set of bitflags. The diagram below shows how they interact with the
+trusted-schema setting described earlier.
+
+![SqliteFunctionBehavior flags and how DIRECTONLY and INNOCUOUS interact with trusted schema](/images/sqlite_function_flags.svg)
+
+- `DETERMINISTIC` declares that the function returns the same output for the same
+  input within a single statement, which lets SQLite cache and hoist calls.
+- `INNOCUOUS` declares that the function is safe to call from schema objects. Under
+  `set_trusted_schema(false)` only `INNOCUOUS` functions may be called from views,
+  triggers, and similar contexts. Only mark a function `INNOCUOUS` if it has no
+  side effects and reveals no internal state.
+- `DIRECTONLY` declares the opposite. The function may not be called from views,
+  triggers, or other schema objects, only from top-level SQL you issue directly.
+  Use this for functions with side effects or that expose application state.
+- `SUBTYPE` declares that the function reads the subtype of one of its arguments.
+
+```rust
+use diesel::sqlite::SqliteFunctionBehavior;
+
+add_one_utils::register_impl_with_behavior(
+    conn,
+    SqliteFunctionBehavior::DETERMINISTIC | SqliteFunctionBehavior::INNOCUOUS,
+    |x: i32| x + 1,
+)?;
+```
+
+### Aggregate functions
+
+Aggregate functions are declared with the same attribute and a type that
+implements
+[`SqliteAggregateFunction`](https://docs.diesel.rs/main/diesel/sqlite/trait.SqliteAggregateFunction.html).
+The generated `register_impl` takes only the connection (the implementation type is
+supplied as a type parameter), and `register_impl_with_behavior` additionally takes
+a `SqliteFunctionBehavior`.
+
+```rust
+my_aggregate_utils::register_impl::<MyAggregate, _>(conn)?;
+
+my_aggregate_utils::register_impl_with_behavior::<MyAggregate, _>(
+    conn,
+    SqliteFunctionBehavior::DETERMINISTIC,
+)?;
+```
+
+## Auto-extensions
+
+Registering hardening settings or custom functions on every connection by hand is
+error prone. SQLite's
+[auto-extension](https://www.sqlite.org/c3ref/auto_extension.html) mechanism runs a
+callback for every new connection opened in the process. Diesel exposes it through
+three free functions in `diesel::sqlite`.
+
+- `register_auto_extension` registers a callback that receives each new
+  `SqliteConnection`.
+- `cancel_auto_extension` removes a previously registered callback.
+- `reset_auto_extension` removes all of them.
+
+```rust
+use diesel::sqlite::{register_auto_extension, SqliteConnection};
+use diesel::QueryResult;
+
+fn harden(conn: &mut SqliteConnection) -> QueryResult<()> {
+    conn.set_defensive(true)?;
+    conn.set_trusted_schema(false)?;
+    conn.set_recommended_security_limits();
+    Ok(())
+}
+
+register_auto_extension(harden)?;
+```
+
+With this in place the hardening recipe (or your custom function registrations)
+runs automatically for every SQLite connection your process opens, including those
+created by a connection pool, so you do not have to apply it at each call site.


### PR DESCRIPTION
Adds a guide documenting the SQLite-only methods Diesel exposes on `SqliteConnection`: connection hardening via `sqlite3_db_config`, resource limits, custom SQL functions with behavior flags, and auto-extensions. Includes two diagrams and registers the guide in the sidebar and guides overview.

Follow-up to diesel-rs/diesel#4976, where @weiznich asked that the diagrams and a short guide live on the website rather than in the crate's rustdoc. The methods are not yet on published `main`, so the doc links will resolve once that PR lands.